### PR TITLE
Write the output paths to an input file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ contain a build.gradle file.
 The command:
 
 ```bash
-gradle clean generateDepTrees -I <path/to/init.gradle> -q
+gradle clean generateDepTrees -I <path/to/init.gradle> -q -Dcom.jfrog.depsTreeOutputFile=<path/to/output/file>
 ```
 
 Output:


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md#tests) passed. If this feature is not already covered by the tests, I added new
  tests.

-----
Resolve https://github.com/jfrog/jfrog-idea-plugin/issues/225
Required for https://github.com/jfrog/ide-plugins-common/pull/85

The output of `generateDepsTree` is paths to dependency tree files, separated by the new line characters.
Running `generateDepTrees` when other Gradle plugins are applied, may add some output to the stdout. As a result, the stdout is no longer parseable.
This PR change this behavior by writing the output to a file, provided by a system property `com.jfrog.depsTreeOutputFile`, instead of to the stdout.