### PR TITLE
fix: prevent OOM when processing large gradle project with many depencies

### DIFF
--- a/src/main/java/com/jfrog/GradleDependencyTreeUtils.java
+++ b/src/main/java/com/jfrog/GradleDependencyTreeUtils.java
@@ -76,6 +76,9 @@ public class GradleDependencyTreeUtils {
     private static void populateTree(GradleDependencyTree node, String configurationName, DependencyResult dependency, Set<String> addedChildren) {
         GradleDependencyTree child = new GradleDependencyTree(configurationName);
         if (dependency instanceof UnresolvedDependencyResult) {
+            if (!addedChildren.add(dependency.getRequested().getDisplayName())) {
+                return;
+            }
             child.setUnresolved(true);
             addChild(node, dependency.getRequested().getDisplayName(), child);
             return;
@@ -91,7 +94,7 @@ public class GradleDependencyTreeUtils {
         }
         addChild(node, moduleVersion.toString(), child);
         for (DependencyResult dependencyResult : resolvedDependency.getSelected().getDependencies()) {
-            populateTree(child, configurationName, dependencyResult, new HashSet<>(addedChildren));
+            populateTree(child, configurationName, dependencyResult, addedChildren);
         }
     }
 


### PR DESCRIPTION
- [X ] All [tests](../CONTRIBUTING.md#tests) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

We have a gradle project with 195 modules that have many interdependencies.
The plugin uses over 100G of memory and eventually fails.
After making these changes it ran quickly in little memory.