### PR TITLE
Added documentation for debugging gradle-dep-tree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,3 +46,17 @@ On Windows run:
 ```
 gradlew.bat clean check
 ```
+
+# 🐞 Debug
+
+To debug the gradle-dep-tree process, follow these steps:
+1) Create a new debug configuration in your IDE. Choose "Remote JVM Debug" and ensure the following fields are correctly configured:
+   * Debugger Mode: Attach to remote JVM
+   * Host: localhost
+   * Post: 5005
+   * Use module classpath: <no module>
+2) Search for the point in your code that triggers the gradle-dep-tree process.
+3) Add the following flags to the command: "-Dorg.gradle.debug=true", "--no-daemon"
+4) When you execute the command with the added flags, the program will freeze. At this point, you can navigate to the gradle-dep-tree code, set a breakpoint, and run the debug configuration in "Debug" mode.
+   This will allow you to resume your original execution inside the gradle-dep-tree code.
+5) Upon exiting the gradle-dep-tree code, the execution of your code before entering the gradle-dep-tree process will be resumed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,13 +50,10 @@ gradlew.bat clean check
 # 🐞 Debug
 
 To debug the gradle-dep-tree process, follow these steps:
-1) Create a new debug configuration in your IDE. Choose "Remote JVM Debug" and ensure the following fields are correctly configured:
+1) Create a new debug configuration in your IDE. If you are using IntelliJ IDEA Choose "Remote JVM Debug" and ensure the following fields are correctly configured:
    * Debugger Mode: Attach to remote JVM
    * Host: localhost
    * Post: 5005
    * Use module classpath: <no module>
-2) Search for the point in your code that triggers the gradle-dep-tree process.
-3) Add the following flags to the command: "-Dorg.gradle.debug=true", "--no-daemon"
-4) When you execute the command with the added flags, the program will freeze. At this point, you can navigate to the gradle-dep-tree code, set a breakpoint, and run the debug configuration in "Debug" mode.
-   This will allow you to resume your original execution inside the gradle-dep-tree code.
-5) Upon exiting the gradle-dep-tree code, the execution of your code before entering the gradle-dep-tree process will be resumed.
+2) Run the Gradle command with following flags: `-Dorg.gradle.debug=true --no-daemon`
+3) After executing the command with the flags, the process will pause. At this juncture, you can set a breakpoint and initiate the debug configuration in "Debug" mode.


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md#tests) passed. If this feature is not already covered by the tests, I added new
  tests.

-----
