### PR TITLE
Fix ConcurrentModificationException with plugins that changes configu…

### DIFF
--- a/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
+++ b/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
@@ -6,7 +6,7 @@ import com.jfrog.Utils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.tasks.*;
 
 import javax.annotation.Nonnull;
@@ -169,8 +169,11 @@ public class GenerateDepTrees extends DefaultTask {
         Map<String, GradleDependencyNode> nodes = new HashMap<>();
         nodes.put(rootId, root);
 
-        for (Configuration configuration : project.getConfigurations()) {
-            addConfiguration(root, configuration, nodes);
+        // getConfigurations() may throw java.util.ConcurrentModificationException in loop
+        ConfigurationContainer configsContainer = project.getConfigurations();
+        Set<String> names = configsContainer.getNames();
+        for (String name : names) {
+            addConfiguration(root, configsContainer.getByName(name), nodes);
         }
         return new GradleDepTreeResults(rootId, nodes);
     }

--- a/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
+++ b/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
@@ -169,7 +169,8 @@ public class GenerateDepTrees extends DefaultTask {
         Map<String, GradleDependencyNode> nodes = new HashMap<>();
         nodes.put(rootId, root);
 
-        // getConfigurations() may throw java.util.ConcurrentModificationException in loop
+        // To prevent ConcurrentModificationException, we clone the configuration names before iterating over them.
+        // This avoids issues caused by dynamic modifications by other Gradle plugins.
         ConfigurationContainer configsContainer = project.getConfigurations();
         Set<String> names = configsContainer.getNames();
         for (String name : names) {


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md#tests) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

Some Gradle plugins (like `io.quarkus`) change the project configurations while running.
When it changes, we get a ConcurrentModificationException while we loop on the configurations
```
Caused by: java.util.ConcurrentModificationException
        at java.base/java.util.TreeMap$PrivateEntryIterator.nextEntry(TreeMap.java:1208)
        at java.base/java.util.TreeMap$KeyIterator.next(TreeMap.java:1262)
        at org.gradle.api.internal.DefaultDomainObjectCollection$IteratorImpl.next(DefaultDomainObjectCollection.java:467)
        at com.jfrog.tasks.GenerateDepTrees.createProjectDependencyTree(GenerateDepTrees.java:173)
        at com.jfrog.tasks.GenerateDepTrees.generateDepTrees(GenerateDepTrees.java:91)
```

This PR takes a 'snapshot' of the names of all the configurations and loops over them. preventing the exception on the iterator.