### PR TITLE
Mark GenerateDepTrees task as incompatible with configuration cache

### DIFF
--- a/src/functionalTest/java/com/jfrog/tasks/FunctionalTestBase.java
+++ b/src/functionalTest/java/com/jfrog/tasks/FunctionalTestBase.java
@@ -27,6 +27,6 @@ public class FunctionalTestBase {
 
     @DataProvider
     public Object[][] gradleVersions() {
-        return new Object[][]{{"5.6.4"}, {"6.9"}, {"7.4.2"}, {"7.6"}};
+        return new Object[][]{{"5.6.4"}, {"6.9"}, {"7.4.2"}, {"7.6"}, {"8.14.2"}};
     }
 }

--- a/src/functionalTest/java/com/jfrog/tasks/IncludeAllBuildFilesTest.java
+++ b/src/functionalTest/java/com/jfrog/tasks/IncludeAllBuildFilesTest.java
@@ -24,6 +24,8 @@ import static org.testng.Assert.fail;
  * Functional tests for the project under resources/multi/
  * This project contain subprojects in a multiple build.gradle files.
  * This project tests the INCLUDE_ALL_BUILD_FILES flag, which should add all the subprojects under resources/multi/.
+ * It uses the configuration cache on Gradle 8.1+.
+ * 
  * @author omerz
  **/
 public class IncludeAllBuildFilesTest extends FunctionalTestBase {

--- a/src/functionalTest/java/com/jfrog/tasks/MultiProjectsTest.java
+++ b/src/functionalTest/java/com/jfrog/tasks/MultiProjectsTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.*;
 /**
  * Functional tests for the project under resources/multi/
  * This project contain subprojects in a multiple build.gradle files.
+ * It uses the configuration cache on Gradle 8.1+.
  *
  * @author yahavi
  **/

--- a/src/functionalTest/resources/multi/gradle.properties
+++ b/src/functionalTest/resources/multi/gradle.properties
@@ -1,1 +1,3 @@
 currentVersion=1.0-SNAPSHOT
+
+org.gradle.configuration-cache=true

--- a/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
+++ b/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.jfrog.GradleDependencyTreeUtils.addConfiguration;
 
@@ -43,6 +44,14 @@ public class GenerateDepTrees extends DefaultTask {
             }
             return true;
         });
+
+        // On Gradle 7.4+, mark this task as incompatible with the configuration cache
+        List<Integer> gradleVersionParts = Arrays.stream(getProject().getGradle().getGradleVersion().split("\\."))
+                .map(Integer::valueOf)
+                .collect(Collectors.toList());
+        if (gradleVersionParts.get(0) >= 8 || (gradleVersionParts.get(0) == 7 && gradleVersionParts.get(1) >= 4)) {
+            notCompatibleWithConfigurationCache("Accesses projects at execution time");
+        }
     }
 
     @Internal


### PR DESCRIPTION
Fixes #25 

The plugin is currently incompatible with Gradle projects using the configuration cache. This affects the JFrog VSCode and IntelliJ plugins as well as they use this plugin.

These changes mark the GenerateDepTrees task as incompatible with the Gradle configuration cache to prevent issues due to project access at execution time. This is a workaround - a better, more permanent solution would be to fix the issues causing configuration cache problems.

- [x] All [tests](../CONTRIBUTING.md#tests) passed. If this feature is not already covered by the tests, I added new
  tests.

-----
