### PR TITLE
Fix `ConcurrentModificationException` in `generateDepTrees` task

### DIFF
--- a/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
+++ b/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
@@ -172,7 +172,7 @@ public class GenerateDepTrees extends DefaultTask {
         // To prevent ConcurrentModificationException, we clone the configuration names before iterating over them.
         // This avoids issues caused by dynamic modifications by other Gradle plugins.
         ConfigurationContainer configsContainer = project.getConfigurations();
-        Set<String> names = configsContainer.getNames();
+        Set<String> names = new HashSet<>(configsContainer.getNames());
         for (String name : names) {
             addConfiguration(root, configsContainer.getByName(name), nodes);
         }


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md#tests) passed. If this feature is not already covered by the tests, I added new
  tests.

-----
The issue was that `configsContainer.getNames()` returns a live view of configuration names, not a copy. When other Gradle plugins or parallel processes modify configurations during iteration, it causes `ConcurrentModificationException`.

The fix creates a copy using `new HashSet<>(configsContainer.getNames())` to prevent concurrent modifications during iteration.
