### PR TITLE
Upgrade test dependencies to latest stable versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,10 +20,10 @@ tasks.compileJava {
 val functionalTest by sourceSets.creating
 
 dependencies {
-    testImplementation("commons-io:commons-io:2.11.0")
+    testImplementation("commons-io:commons-io:2.14.0")
     testImplementation("org.testng:testng:7.7.1")
-    "functionalTestImplementation"("com.fasterxml.jackson.core:jackson-databind:2.14.2")
-    "functionalTestImplementation"("commons-io:commons-io:2.11.0")
+    "functionalTestImplementation"("com.fasterxml.jackson.core:jackson-databind:2.15.3")
+    "functionalTestImplementation"("commons-io:commons-io:2.14.0")
     "functionalTestImplementation"("org.testng:testng:7.7.1")
     "functionalTestImplementation"(project)
 }


### PR DESCRIPTION
- [X] All [tests](../CONTRIBUTING.md#tests) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

- Jackson Databind: 2.14.2 → 2.15.3
- Commons IO: 2.11.0 → 2.14.0