### PR TITLE
Use "included builds" when fetching related projects

### DIFF
--- a/src/test/java/com/jfrog/GradleDepTreeTest.java
+++ b/src/test/java/com/jfrog/GradleDepTreeTest.java
@@ -21,7 +21,7 @@ public class GradleDepTreeTest {
         Project project = ProjectBuilder.builder().build();
         project.getRepositories().maven(repo -> repo.setUrl("https://test.jfrog.io/artifactory/libs-release"));
         System.setProperty(GenerateDepTrees.CURATION_AUDIT_MODE, "true");
-        
+
         new GradleDepTree().apply(project);
 
         MavenArtifactRepository repo = (MavenArtifactRepository) project.getRepositories().iterator().next();
@@ -32,7 +32,7 @@ public class GradleDepTreeTest {
     public void testNoCurationModeNoChange() {
         Project project = ProjectBuilder.builder().build();
         project.getRepositories().maven(repo -> repo.setUrl("https://test.jfrog.io/artifactory/libs-release"));
-        
+
         new GradleDepTree().apply(project);
 
         MavenArtifactRepository repo = (MavenArtifactRepository) project.getRepositories().iterator().next();
@@ -44,7 +44,7 @@ public class GradleDepTreeTest {
         Project project = ProjectBuilder.builder().build();
         project.getRepositories().maven(repo -> repo.setUrl("https://repo1.maven.org/maven2/"));
         System.setProperty(GenerateDepTrees.CURATION_AUDIT_MODE, "true");
-        
+
         new GradleDepTree().apply(project);
 
         MavenArtifactRepository repo = (MavenArtifactRepository) project.getRepositories().iterator().next();
@@ -56,10 +56,22 @@ public class GradleDepTreeTest {
         Project project = ProjectBuilder.builder().build();
         project.getRepositories().maven(repo -> repo.setUrl("https://test.jfrog.io/artifactory/api/curation/audit/libs-release"));
         System.setProperty(GenerateDepTrees.CURATION_AUDIT_MODE, "true");
-        
+
         new GradleDepTree().apply(project);
 
         MavenArtifactRepository repo = (MavenArtifactRepository) project.getRepositories().iterator().next();
         assertEquals(repo.getUrl().toString(), "https://test.jfrog.io/artifactory/api/curation/audit/libs-release");
+    }
+
+    @Test
+    public void testWithIncludedBuilds() {
+        Project project = ProjectBuilder.builder().build();
+        project.getRepositories().maven(repo -> repo.setUrl("https://test.jfrog.io/artifactory/libs-release"));
+        System.setProperty(GenerateDepTrees.INCLUDE_INCLUDED_BUILDS, "true");
+
+        new GradleDepTree().apply(project);
+
+        MavenArtifactRepository repo = (MavenArtifactRepository) project.getRepositories().iterator().next();
+        assertEquals(repo.getUrl().toString(), "https://test.jfrog.io/artifactory/libs-release");
     }
 }


### PR DESCRIPTION
- [x] All [tests](../CONTRIBUTING.md#tests) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

When fetching the related projects, only the subprojects were included. This change allows for the inclusion of "included builds" as well, **only if '-Dcom.jfrog.includeIncludedBuilds=true' is passed to the plugin**
