### PR TITLE
Update jackson-databind to v2.16.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ val functionalTest by sourceSets.creating
 dependencies {
     testImplementation("commons-io:commons-io:2.14.0")
     testImplementation("org.testng:testng:7.7.1")
-    "functionalTestImplementation"("com.fasterxml.jackson.core:jackson-databind:2.15.3")
+    "functionalTestImplementation"("com.fasterxml.jackson.core:jackson-databind:2.16.0")
     "functionalTestImplementation"("commons-io:commons-io:2.14.0")
     "functionalTestImplementation"("org.testng:testng:7.7.1")
     "functionalTestImplementation"(project)


### PR DESCRIPTION
- [ ] All [tests](../CONTRIBUTING.md#tests) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

Update `jackson-databind` to v`2.16.0` (resolve NotApplicable CVE-2023-35116)
