### PR TITLE
Fix dropped transitive deps under project(:foo) with null moduleVersion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ val functionalTest by sourceSets.creating
 dependencies {
     testImplementation("commons-io:commons-io:2.14.0")
     testImplementation("org.testng:testng:7.7.1")
+    testImplementation("org.mockito:mockito-core:4.11.0")
     "functionalTestImplementation"("com.fasterxml.jackson.core:jackson-databind:2.16.0")
     "functionalTestImplementation"("commons-io:commons-io:2.14.0")
     "functionalTestImplementation"("org.testng:testng:7.7.1")

--- a/src/functionalTest/java/com/jfrog/tasks/Consts.java
+++ b/src/functionalTest/java/com/jfrog/tasks/Consts.java
@@ -19,4 +19,7 @@ public class Consts {
     static final Path MULTI = PROJECTS_ROOT.resolve("multi");
     static final Path BASIC = PROJECTS_ROOT.resolve("basic");
     static final Path EMPTY = PROJECTS_ROOT.resolve("empty");
+    // Multi-project fixture where ':middle' has no group/version, transitively pulling in
+    // commons-io. Regression fixture for the project-dep-without-module-version bug fix.
+    static final Path PROJECT_DEP_NO_VERSION = PROJECTS_ROOT.resolve("projectDepNoVersion");
 }

--- a/src/functionalTest/java/com/jfrog/tasks/Consts.java
+++ b/src/functionalTest/java/com/jfrog/tasks/Consts.java
@@ -19,7 +19,6 @@ public class Consts {
     static final Path MULTI = PROJECTS_ROOT.resolve("multi");
     static final Path BASIC = PROJECTS_ROOT.resolve("basic");
     static final Path EMPTY = PROJECTS_ROOT.resolve("empty");
-    // Multi-project fixture where ':middle' has no group/version, transitively pulling in
-    // commons-io. Regression fixture for the project-dep-without-module-version bug fix.
+    // Multi-project fixture for the project-dep-without-module-version regression.
     static final Path PROJECT_DEP_NO_VERSION = PROJECTS_ROOT.resolve("projectDepNoVersion");
 }

--- a/src/functionalTest/java/com/jfrog/tasks/ProjectDepNoVersionTest.java
+++ b/src/functionalTest/java/com/jfrog/tasks/ProjectDepNoVersionTest.java
@@ -1,0 +1,137 @@
+package com.jfrog.tasks;
+
+import com.jfrog.GradleDepTreeResults;
+import com.jfrog.GradleDependencyNode;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.jfrog.tasks.Consts.PROJECT_DEP_NO_VERSION;
+import static com.jfrog.tasks.Consts.TEST_DIR;
+import static com.jfrog.tasks.Utils.generateDepTrees;
+import static com.jfrog.tasks.Utils.objectMapper;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Happy-path smoke test for the project under {@code resources/projectDepNoVersion/}.
+ * <p>
+ * Shaped to mirror the customer scenario that surfaced the {@code populateTree} bug:
+ * a 3-module chain where no subproject declares {@code group} or {@code version}:
+ * <pre>
+ *   :app -> :middle -> :lib -> commons-io:commons-io:2.14.0
+ *                  \-> commons-lang:commons-lang:2.4
+ * </pre>
+ * <p>
+ * <b>Important:</b> stock Gradle (5.6.4 — 8.14.2) always assigns project deps a synthetic
+ * non-null {@link org.gradle.api.artifacts.ModuleVersionIdentifier} of the form
+ * {@code <rootProjectName>:<subproject>:unspecified}, so this fixture does <em>not</em>
+ * trigger the null-moduleVersion early-return that the bug fix targets. Strict regression
+ * coverage for the null-moduleVersion path lives in the Mockito-driven unit test
+ * {@code GradleDependencyTreeUtilsTest#testAddConfiguration_chainOfProjectDepsWithoutModuleVersion_preservesTransitives}.
+ * <p>
+ * What this test <em>does</em> guarantee: the fix introduces no regression on a normal
+ * happy-path multi-module project across all five supported Gradle versions — the chain
+ * still resolves end-to-end and both transitive externals appear in {@code :app}'s tree.
+ *
+ * @author jfrog
+ **/
+public class ProjectDepNoVersionTest extends FunctionalTestBase {
+
+    private static final String COMMONS_IO_ID = "commons-io:commons-io:2.14.0";
+    private static final String COMMONS_LANG_ID = "commons-lang:commons-lang:2.4";
+
+    @BeforeMethod
+    public void setup() throws IOException {
+        setup(PROJECT_DEP_NO_VERSION);
+    }
+
+    @Test(dataProvider = "gradleVersions")
+    public void testMultiModuleChainWithoutGroupAndVersion_remainsHappyPath(String gradleVersion) throws IOException {
+        // Run from the :app sub-project. :app has its own build.gradle, so with
+        // includeAllBuildFiles=false getRelatedProjects() returns only :app -- that's
+        // exactly what we want: a single tree file containing the entire chain.
+        // The plugin always writes its output to the *root project's* build dir, so the
+        // output lives at <root>/build/gradle-dep-tree/, not <root>/app/build/...
+        generateDepTrees(gradleVersion, false, Paths.get("app"));
+        Path outputDir = TEST_DIR.toPath().resolve("build").resolve("gradle-dep-tree");
+
+        try (Stream<Path> files = Files.list(outputDir)) {
+            Set<String> outputFiles = files.map(Path::getFileName).map(Path::toString).collect(Collectors.toSet());
+            assertEquals(outputFiles.size(), 1, "Expected a single tree file for the :app project");
+
+            String onlyFile = outputFiles.iterator().next();
+            GradleDepTreeResults results = objectMapper.readValue(outputDir.resolve(onlyFile).toFile(), GradleDepTreeResults.class);
+            Map<String, GradleDependencyNode> nodes = results.getNodes();
+            GradleDependencyNode root = nodes.get(results.getRoot());
+            assertNotNull(root, "Root node missing from tree");
+
+            // Both transitive externals must survive in :app's tree across all supported
+            // Gradle versions. This proves the post-fix code path stays well-behaved on
+            // the happy path; the null-moduleVersion regression itself is covered by the
+            // Mockito-driven unit test (see class javadoc).
+            assertNodePresentAndReachable(nodes, root, COMMONS_LANG_ID,
+                    "chain :app -> :middle -> commons-lang");
+            assertNodePresentAndReachable(nodes, root, COMMONS_IO_ID,
+                    "chain :app -> :middle -> :lib -> commons-io");
+
+            // Sanity: each surfaced external must carry at least one configuration label
+            // (the resolvable configuration through which it was reached, e.g.
+            // 'compileClasspath'). The exact configuration set varies across Gradle
+            // versions, so we don't assert the specific name.
+            assertTrue(!nodes.get(COMMONS_IO_ID).getConfigurations().isEmpty(),
+                    COMMONS_IO_ID + " must carry at least one configuration");
+            assertTrue(!nodes.get(COMMONS_LANG_ID).getConfigurations().isEmpty(),
+                    COMMONS_LANG_ID + " must carry at least one configuration");
+        }
+    }
+
+    private static void assertNodePresentAndReachable(Map<String, GradleDependencyNode> nodes,
+                                                      GradleDependencyNode root,
+                                                      String targetId,
+                                                      String chainDescription) {
+        assertNotNull(nodes.get(targetId),
+                "Transitive dep '" + targetId + "' is missing from the tree -- "
+                        + chainDescription + " was dropped. "
+                        + "Tree nodes: " + nodes.keySet());
+        assertTrue(reachableFrom(root, targetId, nodes),
+                "'" + targetId + "' is in nodes but not reachable from the root via children "
+                        + "(" + chainDescription + " is broken).");
+    }
+
+    /**
+     * BFS from {@code from} over the {@code children} relation, returning {@code true} if
+     * {@code targetId} is reached. {@code visited} guards against cycles, though the
+     * produced tree should not contain any for this fixture.
+     */
+    private static boolean reachableFrom(GradleDependencyNode from, String targetId, Map<String, GradleDependencyNode> nodes) {
+        Deque<String> stack = new ArrayDeque<>(from.getChildren());
+        Set<String> visited = new HashSet<>();
+        while (!stack.isEmpty()) {
+            String id = stack.pop();
+            if (!visited.add(id)) {
+                continue;
+            }
+            if (targetId.equals(id)) {
+                return true;
+            }
+            GradleDependencyNode child = nodes.get(id);
+            if (child != null) {
+                stack.addAll(child.getChildren());
+            }
+        }
+        return false;
+    }
+}

--- a/src/functionalTest/java/com/jfrog/tasks/ProjectDepNoVersionTest.java
+++ b/src/functionalTest/java/com/jfrog/tasks/ProjectDepNoVersionTest.java
@@ -26,25 +26,13 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 /**
- * Happy-path smoke test for the project under {@code resources/projectDepNoVersion/}.
+ * Happy-path smoke test for a 3-module chain ({@code :app -> :middle -> :lib -> commons-io},
+ * also {@code :middle -> commons-lang}) where no subproject declares {@code group}/{@code version}.
  * <p>
- * Shaped to mirror the customer scenario that surfaced the {@code populateTree} bug:
- * a 3-module chain where no subproject declares {@code group} or {@code version}:
- * <pre>
- *   :app -> :middle -> :lib -> commons-io:commons-io:2.14.0
- *                  \-> commons-lang:commons-lang:2.4
- * </pre>
- * <p>
- * <b>Important:</b> stock Gradle (5.6.4 — 8.14.2) always assigns project deps a synthetic
- * non-null {@link org.gradle.api.artifacts.ModuleVersionIdentifier} of the form
- * {@code <rootProjectName>:<subproject>:unspecified}, so this fixture does <em>not</em>
- * trigger the null-moduleVersion early-return that the bug fix targets. Strict regression
- * coverage for the null-moduleVersion path lives in the Mockito-driven unit test
- * {@code GradleDependencyTreeUtilsTest#testAddConfiguration_chainOfProjectDepsWithoutModuleVersion_preservesTransitives}.
- * <p>
- * What this test <em>does</em> guarantee: the fix introduces no regression on a normal
- * happy-path multi-module project across all five supported Gradle versions — the chain
- * still resolves end-to-end and both transitive externals appear in {@code :app}'s tree.
+ * Stock Gradle (5.6.4 — 8.14.2) synthesises a non-null {@code ModuleVersionIdentifier} for
+ * project deps, so this fixture does <em>not</em> trigger the null-moduleVersion path —
+ * strict coverage of that path lives in {@code GradleDependencyTreeUtilsTest}. This test
+ * just asserts the fix doesn't regress the happy path across all supported Gradle versions.
  *
  * @author jfrog
  **/
@@ -60,11 +48,9 @@ public class ProjectDepNoVersionTest extends FunctionalTestBase {
 
     @Test(dataProvider = "gradleVersions")
     public void testMultiModuleChainWithoutGroupAndVersion_remainsHappyPath(String gradleVersion) throws IOException {
-        // Run from the :app sub-project. :app has its own build.gradle, so with
-        // includeAllBuildFiles=false getRelatedProjects() returns only :app -- that's
-        // exactly what we want: a single tree file containing the entire chain.
-        // The plugin always writes its output to the *root project's* build dir, so the
-        // output lives at <root>/build/gradle-dep-tree/, not <root>/app/build/...
+        // Run from :app — with includeAllBuildFiles=false, getRelatedProjects() returns only
+        // :app, so we get a single tree file with the whole chain. Output goes to the root
+        // project's build dir (<root>/build/gradle-dep-tree/), not <root>/app/build/.
         generateDepTrees(gradleVersion, false, Paths.get("app"));
         Path outputDir = TEST_DIR.toPath().resolve("build").resolve("gradle-dep-tree");
 
@@ -78,19 +64,12 @@ public class ProjectDepNoVersionTest extends FunctionalTestBase {
             GradleDependencyNode root = nodes.get(results.getRoot());
             assertNotNull(root, "Root node missing from tree");
 
-            // Both transitive externals must survive in :app's tree across all supported
-            // Gradle versions. This proves the post-fix code path stays well-behaved on
-            // the happy path; the null-moduleVersion regression itself is covered by the
-            // Mockito-driven unit test (see class javadoc).
             assertNodePresentAndReachable(nodes, root, COMMONS_LANG_ID,
                     "chain :app -> :middle -> commons-lang");
             assertNodePresentAndReachable(nodes, root, COMMONS_IO_ID,
                     "chain :app -> :middle -> :lib -> commons-io");
 
-            // Sanity: each surfaced external must carry at least one configuration label
-            // (the resolvable configuration through which it was reached, e.g.
-            // 'compileClasspath'). The exact configuration set varies across Gradle
-            // versions, so we don't assert the specific name.
+            // Each surfaced external must carry at least one config label; exact name varies by Gradle version.
             assertTrue(!nodes.get(COMMONS_IO_ID).getConfigurations().isEmpty(),
                     COMMONS_IO_ID + " must carry at least one configuration");
             assertTrue(!nodes.get(COMMONS_LANG_ID).getConfigurations().isEmpty(),
@@ -111,11 +90,7 @@ public class ProjectDepNoVersionTest extends FunctionalTestBase {
                         + "(" + chainDescription + " is broken).");
     }
 
-    /**
-     * BFS from {@code from} over the {@code children} relation, returning {@code true} if
-     * {@code targetId} is reached. {@code visited} guards against cycles, though the
-     * produced tree should not contain any for this fixture.
-     */
+    /** BFS over children; visited guards against cycles. */
     private static boolean reachableFrom(GradleDependencyNode from, String targetId, Map<String, GradleDependencyNode> nodes) {
         Deque<String> stack = new ArrayDeque<>(from.getChildren());
         Set<String> visited = new HashSet<>();

--- a/src/functionalTest/resources/projectDepNoVersion/app/build.gradle
+++ b/src/functionalTest/resources/projectDepNoVersion/app/build.gradle
@@ -1,0 +1,7 @@
+// :app declares NO direct external deps — it depends only on :middle.
+// If `populateTree` drops the project subtree on null moduleVersion,
+// :app's tree will lose visibility of every transitive below :middle
+// (including the externals declared in :middle and :lib).
+dependencies {
+    implementation project(':middle')
+}

--- a/src/functionalTest/resources/projectDepNoVersion/app/build.gradle
+++ b/src/functionalTest/resources/projectDepNoVersion/app/build.gradle
@@ -1,7 +1,4 @@
-// :app declares NO direct external deps — it depends only on :middle.
-// If `populateTree` drops the project subtree on null moduleVersion,
-// :app's tree will lose visibility of every transitive below :middle
-// (including the externals declared in :middle and :lib).
+// :app has only a project dep — so all asserted externals reach it via the project-dep chain.
 dependencies {
     implementation project(':middle')
 }

--- a/src/functionalTest/resources/projectDepNoVersion/app/src/main/java/com/example/App.java
+++ b/src/functionalTest/resources/projectDepNoVersion/app/src/main/java/com/example/App.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class App {
+    public static void main(String[] args) {
+        System.out.println("App");
+    }
+}

--- a/src/functionalTest/resources/projectDepNoVersion/build.gradle
+++ b/src/functionalTest/resources/projectDepNoVersion/build.gradle
@@ -1,0 +1,23 @@
+// Happy-path smoke test: multi-module chain (:app -> :middle -> :lib -> external)
+// where no subproject declares `group` or `version`. Ensures the new project-dep
+// node-id resolution does not regress the common case across all supported Gradle
+// versions. Strict regression coverage for the null-moduleVersion path is in the
+// Mockito unit test (see ProjectDepNoVersionTest's class javadoc).
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+
+plugins {
+    id 'com.jfrog.gradle-dep-tree'
+}
+
+subprojects {
+    apply plugin: 'java-library'
+
+    repositories {
+        mavenCentral()
+    }
+}

--- a/src/functionalTest/resources/projectDepNoVersion/build.gradle
+++ b/src/functionalTest/resources/projectDepNoVersion/build.gradle
@@ -1,8 +1,5 @@
-// Happy-path smoke test: multi-module chain (:app -> :middle -> :lib -> external)
-// where no subproject declares `group` or `version`. Ensures the new project-dep
-// node-id resolution does not regress the common case across all supported Gradle
-// versions. Strict regression coverage for the null-moduleVersion path is in the
-// Mockito unit test (see ProjectDepNoVersionTest's class javadoc).
+// Multi-module chain (:app -> :middle -> :lib -> external) with no group/version on subprojects.
+// Happy-path regression guard for the project-dep-without-module-version fix.
 
 buildscript {
     repositories {

--- a/src/functionalTest/resources/projectDepNoVersion/lib/build.gradle
+++ b/src/functionalTest/resources/projectDepNoVersion/lib/build.gradle
@@ -1,0 +1,6 @@
+// :lib is the deepest module — it owns the leaf external dep that should
+// surface all the way up to :app's tree if the project-dep chain is walked
+// correctly.
+dependencies {
+    api 'commons-io:commons-io:2.14.0'
+}

--- a/src/functionalTest/resources/projectDepNoVersion/lib/build.gradle
+++ b/src/functionalTest/resources/projectDepNoVersion/lib/build.gradle
@@ -1,6 +1,4 @@
-// :lib is the deepest module — it owns the leaf external dep that should
-// surface all the way up to :app's tree if the project-dep chain is walked
-// correctly.
+// :lib owns the leaf external dep that must surface in :app's tree if the chain is walked correctly.
 dependencies {
     api 'commons-io:commons-io:2.14.0'
 }

--- a/src/functionalTest/resources/projectDepNoVersion/lib/src/main/java/com/example/Lib.java
+++ b/src/functionalTest/resources/projectDepNoVersion/lib/src/main/java/com/example/Lib.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public class Lib {
+}

--- a/src/functionalTest/resources/projectDepNoVersion/middle/build.gradle
+++ b/src/functionalTest/resources/projectDepNoVersion/middle/build.gradle
@@ -1,6 +1,5 @@
-// :middle bridges :app and :lib, and adds one external dep of its own
-// (commons-lang) so we can independently assert the chain segment
-// :app -> :middle -> commons-lang vs the deeper :app -> :middle -> :lib -> commons-io.
+// :middle bridges :app and :lib, plus its own external dep so the two chain
+// segments (:middle -> commons-lang vs :middle -> :lib -> commons-io) can be asserted separately.
 dependencies {
     api project(':lib')
     api 'commons-lang:commons-lang:2.4'

--- a/src/functionalTest/resources/projectDepNoVersion/middle/build.gradle
+++ b/src/functionalTest/resources/projectDepNoVersion/middle/build.gradle
@@ -1,0 +1,7 @@
+// :middle bridges :app and :lib, and adds one external dep of its own
+// (commons-lang) so we can independently assert the chain segment
+// :app -> :middle -> commons-lang vs the deeper :app -> :middle -> :lib -> commons-io.
+dependencies {
+    api project(':lib')
+    api 'commons-lang:commons-lang:2.4'
+}

--- a/src/functionalTest/resources/projectDepNoVersion/middle/src/main/java/com/example/Middle.java
+++ b/src/functionalTest/resources/projectDepNoVersion/middle/src/main/java/com/example/Middle.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public class Middle {
+}

--- a/src/functionalTest/resources/projectDepNoVersion/settings.gradle
+++ b/src/functionalTest/resources/projectDepNoVersion/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'projectDepNoVersion'
+include 'app', 'middle', 'lib'

--- a/src/main/java/com/jfrog/GradleDependencyTreeUtils.java
+++ b/src/main/java/com/jfrog/GradleDependencyTreeUtils.java
@@ -1,8 +1,11 @@
 package com.jfrog;
 
+import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
@@ -26,13 +29,20 @@ public class GradleDependencyTreeUtils {
     /**
      * Add Gradle configuration including its all dependencies.
      *
+     * @param ownerProject  the Gradle project that owns the configuration being walked. Used by
+     *                      {@link #synthesizeProjectNodeId(Project, ProjectComponentIdentifier)}
+     *                      to look up sibling subprojects when a project dependency's
+     *                      {@code ResolvedComponentResult} returns a {@code null}
+     *                      {@link ModuleVersionIdentifier}; may be {@code null} (in which case
+     *                      the synthesizer falls back to a path-based id with placeholder
+     *                      group/version, the pre-fix behaviour).
      * @param root          the root node
      * @param configuration resolved or unresolved Gradle configuration
      * @param nodes         a map of all nodes mapped by their module ID (group:name:version)
      */
-    public static void addConfiguration(GradleDependencyNode root, Configuration configuration, Map<String, GradleDependencyNode> nodes) {
+    public static void addConfiguration(Project ownerProject, GradleDependencyNode root, Configuration configuration, Map<String, GradleDependencyNode> nodes) {
         if (configuration.isCanBeResolved()) {
-            addResolvedConfiguration(root, configuration, nodes);
+            addResolvedConfiguration(ownerProject, root, configuration, nodes);
         } else {
             addUnresolvedConfiguration(root, configuration, nodes);
         }
@@ -41,16 +51,17 @@ public class GradleDependencyTreeUtils {
     /**
      * Add resolved configuration. A resolved configuration may contain transitive dependencies.
      *
+     * @param ownerProject  see {@link #addConfiguration(Project, GradleDependencyNode, Configuration, Map)}
      * @param root          the root node
      * @param configuration resolved Gradle configuration
      * @param nodes         a map of all nodes mapped by their module ID (group:name:version)
      */
-    private static void addResolvedConfiguration(GradleDependencyNode root, Configuration configuration, Map<String, GradleDependencyNode> nodes) {
+    private static void addResolvedConfiguration(Project ownerProject, GradleDependencyNode root, Configuration configuration, Map<String, GradleDependencyNode> nodes) {
         root.getConfigurations().add(configuration.getName());
         ResolvedComponentResult componentResult = configuration.getIncoming().getResolutionResult().getRoot();
         Map<String, Integer> depPopulations = new HashMap<>();
         for (DependencyResult dependency : componentResult.getDependencies()) {
-            populateTree(root, configuration.getName(), dependency, new HashSet<>(), nodes, depPopulations);
+            populateTree(ownerProject, root, configuration.getName(), dependency, new HashSet<>(), nodes, depPopulations);
         }
     }
 
@@ -68,7 +79,10 @@ public class GradleDependencyTreeUtils {
             if (dependency.getVersion() != null) {
                 // If the version is null, the dependency does not contain an ID and we should not add it.
                 // For example: "implementation gradleApi()"
-                addChild(root, String.join(":", dependency.getGroup(), dependency.getName(), dependency.getVersion()), child, nodes);
+                // Route through the central Utils.buildModuleId helper so a null group does not
+                // produce a literal "null:foo:1.0" key — see Utils.UNSPECIFIED_ID_PART javadoc
+                // for why the placeholder must stay consistent across all id-producing sites.
+                addChild(root, Utils.buildModuleId(dependency.getGroup(), dependency.getName(), dependency.getVersion()), child, nodes);
             }
         }
     }
@@ -76,6 +90,9 @@ public class GradleDependencyTreeUtils {
     /**
      * Recursively populate the dependency tree.
      *
+     * @param ownerProject      the project that owns the configuration being walked — passed
+     *                          unchanged through recursion so {@link #synthesizeProjectNodeId}
+     *                          can look up sibling subprojects by their absolute path
      * @param node              the parent node
      * @param configurationName the configuration name
      * @param dependency        resolved or unresolved dependency
@@ -83,7 +100,7 @@ public class GradleDependencyTreeUtils {
      * @param nodes             a map of all nodes mapped by their module ID (group:name:version)
      * @param depPopulations    a map of all node population counters mapped by their module ID (group:name:version)
      */
-    private static void populateTree(GradleDependencyNode node, String configurationName, DependencyResult dependency, Set<String> addedChildren, Map<String, GradleDependencyNode> nodes, Map<String, Integer> depPopulations) {
+    private static void populateTree(Project ownerProject, GradleDependencyNode node, String configurationName, DependencyResult dependency, Set<String> addedChildren, Map<String, GradleDependencyNode> nodes, Map<String, Integer> depPopulations) {
         GradleDependencyNode child = new GradleDependencyNode(configurationName);
         if (dependency instanceof UnresolvedDependencyResult) {
             child.setUnresolved(true);
@@ -91,21 +108,121 @@ public class GradleDependencyTreeUtils {
             return;
         }
         ResolvedDependencyResult resolvedDependency = (ResolvedDependencyResult) dependency;
-        ModuleVersionIdentifier moduleVersion = resolvedDependency.getSelected().getModuleVersion();
-        if (moduleVersion == null) {
-            // If there is no module version, then the dependency was not found in any repository
+        ResolvedComponentResult selected = resolvedDependency.getSelected();
+        String nodeId = resolveNodeId(ownerProject, selected);
+        if (nodeId == null) {
+            // The component has no usable identity — typically an external dependency that
+            // was not found in any repository, or a less common ComponentIdentifier subtype
+            // (e.g. LibraryBinaryIdentifier for native/JVM library variants) for which we
+            // have no synthesizer. Anything below it is unreachable, so dropping it is safe.
             return;
         }
-        String nodeId = moduleVersion.toString();
         int populations = depPopulations.getOrDefault(nodeId, 0);
         if (!addedChildren.add(nodeId) || populations >= MAX_DEP_POPULATIONS_IN_CONFIG) {
             return;
         }
         depPopulations.put(nodeId, populations + 1);
-        for (DependencyResult dependencyResult : resolvedDependency.getSelected().getDependencies()) {
-            populateTree(child, configurationName, dependencyResult, new HashSet<>(addedChildren), nodes, depPopulations);
+        for (DependencyResult dependencyResult : selected.getDependencies()) {
+            populateTree(ownerProject, child, configurationName, dependencyResult, new HashSet<>(addedChildren), nodes, depPopulations);
         }
         addChild(node, nodeId, child, nodes);
+    }
+
+    /**
+     * Resolve a stable node id for a resolved component.
+     * <p>
+     * For external module dependencies, the id is the {@link ModuleVersionIdentifier#toString()}
+     * (group:name:version) — same behaviour as before.
+     * <p>
+     * For local project dependencies (e.g. {@code project(":foo")}),
+     * {@link ResolvedComponentResult#getModuleVersion()} is annotated {@code @Nullable} and can
+     * return {@code null} when the referenced subproject has no {@code group}/{@code version}
+     * configured AND the runtime/plugin combination doesn't synthesize the usual
+     * {@code rootProjectName:subproject:unspecified} fallback. Stock Gradle 5.6.4 — 8.14.2 does
+     * synthesize that fallback, so the null path is exercised in production by recent JDKs +
+     * Gradle 8.14+ in combination with plugins that rewrite resolution metadata
+     * (notably {@code io.spring.dependency-management} on a Kotlin DSL build, observed at the
+     * customer that surfaced this bug). Returning early in that case (the previous behaviour)
+     * silently dropped the entire transitive subtree below the project dependency.
+     * <p>
+     * Instead of dropping the subtree, we look up the actual subproject via
+     * {@link Project#findProject(String)} on the {@code ownerProject} and synthesize an id from
+     * its real {@code group}/{@code name}/{@code version} — the exact same string
+     * {@code GenerateDepTrees#getProjectModuleId} would produce when generating that
+     * subproject's own dependency-tree file. This keeps the cross-site centralisation invariant
+     * (see {@link Utils#UNSPECIFIED_ID_PART}) actually true, so per-subproject tree files merge
+     * correctly downstream — without it, downstream consumers like {@code jf curation-audit}
+     * see only a fraction of the real blocked-package signal because parent trees reference
+     * project deps by ids that don't match the child trees' root ids.
+     *
+     * @param ownerProject the project owning the configuration being walked; may be
+     *                     {@code null} (in which case the synthesizer falls back to the
+     *                     path-based id with placeholder group/version)
+     * @param selected     the resolved component
+     * @return the node id, or {@code null} if the component truly has no usable identity
+     */
+    static String resolveNodeId(Project ownerProject, ResolvedComponentResult selected) {
+        ModuleVersionIdentifier moduleVersion = selected.getModuleVersion();
+        if (moduleVersion != null) {
+            return moduleVersion.toString();
+        }
+        ComponentIdentifier id = selected.getId();
+        if (id instanceof ProjectComponentIdentifier) {
+            return synthesizeProjectNodeId(ownerProject, (ProjectComponentIdentifier) id);
+        }
+        return null;
+    }
+
+    /**
+     * Build a node id for a project component dependency that has no
+     * {@link ModuleVersionIdentifier}. The result MUST equal what
+     * {@code GenerateDepTrees#getProjectModuleId} produces for the same subproject —
+     * otherwise the per-subproject tree files won't merge correctly downstream
+     * (the parent's reference and the child's own root use different keys).
+     * <p>
+     * Strategy:
+     * <ol>
+     *   <li>If {@code ownerProject} is non-null and {@link Project#findProject(String)}
+     *       resolves the path, use the subproject's actual {@code group}/{@code name}/
+     *       {@code version} via {@link Utils#buildModuleId(String, String, String)}.
+     *       This is the path that satisfies the centralisation invariant.</li>
+     *   <li>Otherwise, fall back to a path-based id with placeholder group/version.
+     *       This covers cross-build references (composite/included builds) and any
+     *       case where the lookup fails. The fallback id won't merge cleanly with the
+     *       child tree's root id — same drawback the pre-fix behaviour had — but it's
+     *       still better than dropping the subtree entirely.</li>
+     * </ol>
+     * <p>
+     * Note on collisions: in the lookup path we use the resolved subproject's own
+     * {@code Project.getName()}, so this matches {@code getProjectModuleId} exactly,
+     * including the pre-existing collision behaviour where sibling subprojects with
+     * identical leaf names (e.g. {@code :foo:lib} and {@code :bar:lib}) collapse in the
+     * nodes map. Do not "fix" that here without also changing {@code getProjectModuleId}.
+     *
+     * @param ownerProject the project owning the configuration being walked; may be {@code null}
+     * @param id           the project component identifier
+     */
+    static String synthesizeProjectNodeId(Project ownerProject, ProjectComponentIdentifier id) {
+        String path = id.getProjectPath();
+        if (path == null) {
+            return Utils.buildModuleId(null, null, null);
+        }
+        if (ownerProject != null) {
+            Project subproject = ownerProject.findProject(path);
+            if (subproject != null) {
+                // Mirror GenerateDepTrees#getProjectModuleId exactly — same helper, same inputs.
+                return Utils.buildModuleId(
+                        subproject.getGroup().toString(),
+                        subproject.getName(),
+                        subproject.getVersion().toString());
+            }
+        }
+        // Fallback: cross-build references or unresolvable paths. Less ideal (won't merge
+        // with the child tree's root id) but preserves visibility rather than dropping the
+        // chain. Documented in the javadoc above.
+        int lastColon = path.lastIndexOf(':');
+        String name = lastColon >= 0 ? path.substring(lastColon + 1) : path;
+        return Utils.buildModuleId(null, name, null);
     }
 
     /**

--- a/src/main/java/com/jfrog/GradleDependencyTreeUtils.java
+++ b/src/main/java/com/jfrog/GradleDependencyTreeUtils.java
@@ -29,13 +29,9 @@ public class GradleDependencyTreeUtils {
     /**
      * Add Gradle configuration including its all dependencies.
      *
-     * @param ownerProject  the Gradle project that owns the configuration being walked. Used by
-     *                      {@link #synthesizeProjectNodeId(Project, ProjectComponentIdentifier)}
-     *                      to look up sibling subprojects when a project dependency's
-     *                      {@code ResolvedComponentResult} returns a {@code null}
-     *                      {@link ModuleVersionIdentifier}; may be {@code null} (in which case
-     *                      the synthesizer falls back to a path-based id with placeholder
-     *                      group/version, the pre-fix behaviour).
+     * @param ownerProject  the project owning {@code configuration}, used to look up sibling
+     *                      subprojects when a project dep has no {@link ModuleVersionIdentifier};
+     *                      may be {@code null}
      * @param root          the root node
      * @param configuration resolved or unresolved Gradle configuration
      * @param nodes         a map of all nodes mapped by their module ID (group:name:version)
@@ -50,11 +46,6 @@ public class GradleDependencyTreeUtils {
 
     /**
      * Add resolved configuration. A resolved configuration may contain transitive dependencies.
-     *
-     * @param ownerProject  see {@link #addConfiguration(Project, GradleDependencyNode, Configuration, Map)}
-     * @param root          the root node
-     * @param configuration resolved Gradle configuration
-     * @param nodes         a map of all nodes mapped by their module ID (group:name:version)
      */
     private static void addResolvedConfiguration(Project ownerProject, GradleDependencyNode root, Configuration configuration, Map<String, GradleDependencyNode> nodes) {
         root.getConfigurations().add(configuration.getName());
@@ -77,11 +68,8 @@ public class GradleDependencyTreeUtils {
             GradleDependencyNode child = new GradleDependencyNode(configuration.getName());
             child.setUnresolved(true);
             if (dependency.getVersion() != null) {
-                // If the version is null, the dependency does not contain an ID and we should not add it.
-                // For example: "implementation gradleApi()"
-                // Route through the central Utils.buildModuleId helper so a null group does not
-                // produce a literal "null:foo:1.0" key — see Utils.UNSPECIFIED_ID_PART javadoc
-                // for why the placeholder must stay consistent across all id-producing sites.
+                // Skip deps with no version (e.g. "implementation gradleApi()").
+                // Use buildModuleId so a null group becomes "unspecified" instead of the literal "null".
                 addChild(root, Utils.buildModuleId(dependency.getGroup(), dependency.getName(), dependency.getVersion()), child, nodes);
             }
         }
@@ -90,9 +78,8 @@ public class GradleDependencyTreeUtils {
     /**
      * Recursively populate the dependency tree.
      *
-     * @param ownerProject      the project that owns the configuration being walked — passed
-     *                          unchanged through recursion so {@link #synthesizeProjectNodeId}
-     *                          can look up sibling subprojects by their absolute path
+     * @param ownerProject      see {@link #addConfiguration} — passed unchanged through recursion
+     *                          so the project-dep synthesizer can look up sibling subprojects
      * @param node              the parent node
      * @param configurationName the configuration name
      * @param dependency        resolved or unresolved dependency
@@ -111,10 +98,7 @@ public class GradleDependencyTreeUtils {
         ResolvedComponentResult selected = resolvedDependency.getSelected();
         String nodeId = resolveNodeId(ownerProject, selected);
         if (nodeId == null) {
-            // The component has no usable identity — typically an external dependency that
-            // was not found in any repository, or a less common ComponentIdentifier subtype
-            // (e.g. LibraryBinaryIdentifier for native/JVM library variants) for which we
-            // have no synthesizer. Anything below it is unreachable, so dropping it is safe.
+            // No usable identity (external dep not in any repo, or unsupported ComponentIdentifier subtype).
             return;
         }
         int populations = depPopulations.getOrDefault(nodeId, 0);
@@ -131,35 +115,12 @@ public class GradleDependencyTreeUtils {
     /**
      * Resolve a stable node id for a resolved component.
      * <p>
-     * For external module dependencies, the id is the {@link ModuleVersionIdentifier#toString()}
-     * (group:name:version) — same behaviour as before.
-     * <p>
-     * For local project dependencies (e.g. {@code project(":foo")}),
-     * {@link ResolvedComponentResult#getModuleVersion()} is annotated {@code @Nullable} and can
-     * return {@code null} when the referenced subproject has no {@code group}/{@code version}
-     * configured AND the runtime/plugin combination doesn't synthesize the usual
-     * {@code rootProjectName:subproject:unspecified} fallback. Stock Gradle 5.6.4 — 8.14.2 does
-     * synthesize that fallback, so the null path is exercised in production by recent JDKs +
-     * Gradle 8.14+ in combination with plugins that rewrite resolution metadata
-     * (notably {@code io.spring.dependency-management} on a Kotlin DSL build, observed at the
-     * customer that surfaced this bug). Returning early in that case (the previous behaviour)
-     * silently dropped the entire transitive subtree below the project dependency.
-     * <p>
-     * Instead of dropping the subtree, we look up the actual subproject via
-     * {@link Project#findProject(String)} on the {@code ownerProject} and synthesize an id from
-     * its real {@code group}/{@code name}/{@code version} — the exact same string
-     * {@code GenerateDepTrees#getProjectModuleId} would produce when generating that
-     * subproject's own dependency-tree file. This keeps the cross-site centralisation invariant
-     * (see {@link Utils#UNSPECIFIED_ID_PART}) actually true, so per-subproject tree files merge
-     * correctly downstream — without it, downstream consumers like {@code jf curation-audit}
-     * see only a fraction of the real blocked-package signal because parent trees reference
-     * project deps by ids that don't match the child trees' root ids.
+     * External deps return {@link ModuleVersionIdentifier#toString()}. Local project deps
+     * whose {@code getModuleVersion()} is {@code null} (observed with recent JDKs + Gradle
+     * 8.14+ + plugins that rewrite resolution metadata, e.g. {@code io.spring.dependency-management})
+     * fall through to {@link #synthesizeProjectNodeId} instead of being dropped.
      *
-     * @param ownerProject the project owning the configuration being walked; may be
-     *                     {@code null} (in which case the synthesizer falls back to the
-     *                     path-based id with placeholder group/version)
-     * @param selected     the resolved component
-     * @return the node id, or {@code null} if the component truly has no usable identity
+     * @return the node id, or {@code null} if the component has no usable identity
      */
     static String resolveNodeId(Project ownerProject, ResolvedComponentResult selected) {
         ModuleVersionIdentifier moduleVersion = selected.getModuleVersion();
@@ -174,33 +135,14 @@ public class GradleDependencyTreeUtils {
     }
 
     /**
-     * Build a node id for a project component dependency that has no
-     * {@link ModuleVersionIdentifier}. The result MUST equal what
-     * {@code GenerateDepTrees#getProjectModuleId} produces for the same subproject —
-     * otherwise the per-subproject tree files won't merge correctly downstream
-     * (the parent's reference and the child's own root use different keys).
+     * Build a node id for a project component with no {@link ModuleVersionIdentifier}.
+     * The result MUST equal {@code GenerateDepTrees#getProjectModuleId}'s output for the
+     * same subproject, otherwise per-subproject tree files won't merge downstream.
      * <p>
-     * Strategy:
-     * <ol>
-     *   <li>If {@code ownerProject} is non-null and {@link Project#findProject(String)}
-     *       resolves the path, use the subproject's actual {@code group}/{@code name}/
-     *       {@code version} via {@link Utils#buildModuleId(String, String, String)}.
-     *       This is the path that satisfies the centralisation invariant.</li>
-     *   <li>Otherwise, fall back to a path-based id with placeholder group/version.
-     *       This covers cross-build references (composite/included builds) and any
-     *       case where the lookup fails. The fallback id won't merge cleanly with the
-     *       child tree's root id — same drawback the pre-fix behaviour had — but it's
-     *       still better than dropping the subtree entirely.</li>
-     * </ol>
-     * <p>
-     * Note on collisions: in the lookup path we use the resolved subproject's own
-     * {@code Project.getName()}, so this matches {@code getProjectModuleId} exactly,
-     * including the pre-existing collision behaviour where sibling subprojects with
-     * identical leaf names (e.g. {@code :foo:lib} and {@code :bar:lib}) collapse in the
-     * nodes map. Do not "fix" that here without also changing {@code getProjectModuleId}.
-     *
-     * @param ownerProject the project owning the configuration being walked; may be {@code null}
-     * @param id           the project component identifier
+     * If {@link Project#findProject(String)} resolves the path, use the subproject's actual
+     * {@code group}/{@code name}/{@code version}. Otherwise (cross-build refs, lookup miss)
+     * fall back to a path-based id with {@link Utils#UNSPECIFIED_ID_PART} placeholders —
+     * the chain survives, but the id won't merge cleanly with the child tree's root.
      */
     static String synthesizeProjectNodeId(Project ownerProject, ProjectComponentIdentifier id) {
         String path = id.getProjectPath();
@@ -210,16 +152,12 @@ public class GradleDependencyTreeUtils {
         if (ownerProject != null) {
             Project subproject = ownerProject.findProject(path);
             if (subproject != null) {
-                // Mirror GenerateDepTrees#getProjectModuleId exactly — same helper, same inputs.
                 return Utils.buildModuleId(
                         subproject.getGroup().toString(),
                         subproject.getName(),
                         subproject.getVersion().toString());
             }
         }
-        // Fallback: cross-build references or unresolvable paths. Less ideal (won't merge
-        // with the child tree's root id) but preserves visibility rather than dropping the
-        // chain. Documented in the javadoc above.
         int lastColon = path.lastIndexOf(':');
         String name = lastColon >= 0 ? path.substring(lastColon + 1) : path;
         return Utils.buildModuleId(null, name, null);

--- a/src/main/java/com/jfrog/Utils.java
+++ b/src/main/java/com/jfrog/Utils.java
@@ -16,26 +16,15 @@ public class Utils {
     private static final String indentationSpace = "  ";
 
     /**
-     * Placeholder used in place of any missing component of a Gradle module id
-     * (group / name / version) when the underlying value is null or empty.
-     * Centralised so that all sites producing module ids stay in sync: both
-     * project root ids (see {@code GenerateDepTrees#getProjectModuleId}) and
-     * synthesized project-dep ids (see
-     * {@code GradleDependencyTreeUtils#synthesizeProjectNodeId}) must agree on
-     * this value, otherwise the dependency-tree files for sibling sub-projects
-     * will not merge correctly downstream.
+     * Placeholder for any missing component of a Gradle module id (group / name / version).
+     * All id-producing sites must agree on this value or per-subproject tree files won't
+     * merge correctly downstream.
      */
     public static final String UNSPECIFIED_ID_PART = "unspecified";
 
     /**
-     * Build a Gradle module id of the form {@code group:name:version}, replacing
-     * any null/empty component with {@link #UNSPECIFIED_ID_PART}. Use this from
-     * any code that produces a module id so the placeholder stays consistent.
-     *
-     * @param group   the group component (may be null/empty)
-     * @param name    the name component (may be null/empty)
-     * @param version the version component (may be null/empty)
-     * @return the joined id, never null
+     * Build a {@code group:name:version} module id, substituting {@link #UNSPECIFIED_ID_PART}
+     * for any null/empty component. Single source of truth for the placeholder format.
      */
     public static String buildModuleId(String group, String name, String version) {
         return String.join(":", orUnspecified(group), orUnspecified(name), orUnspecified(version));

--- a/src/main/java/com/jfrog/Utils.java
+++ b/src/main/java/com/jfrog/Utils.java
@@ -15,6 +15,36 @@ import static java.lang.System.lineSeparator;
 public class Utils {
     private static final String indentationSpace = "  ";
 
+    /**
+     * Placeholder used in place of any missing component of a Gradle module id
+     * (group / name / version) when the underlying value is null or empty.
+     * Centralised so that all sites producing module ids stay in sync: both
+     * project root ids (see {@code GenerateDepTrees#getProjectModuleId}) and
+     * synthesized project-dep ids (see
+     * {@code GradleDependencyTreeUtils#synthesizeProjectNodeId}) must agree on
+     * this value, otherwise the dependency-tree files for sibling sub-projects
+     * will not merge correctly downstream.
+     */
+    public static final String UNSPECIFIED_ID_PART = "unspecified";
+
+    /**
+     * Build a Gradle module id of the form {@code group:name:version}, replacing
+     * any null/empty component with {@link #UNSPECIFIED_ID_PART}. Use this from
+     * any code that produces a module id so the placeholder stays consistent.
+     *
+     * @param group   the group component (may be null/empty)
+     * @param name    the name component (may be null/empty)
+     * @param version the version component (may be null/empty)
+     * @return the joined id, never null
+     */
+    public static String buildModuleId(String group, String name, String version) {
+        return String.join(":", orUnspecified(group), orUnspecified(name), orUnspecified(version));
+    }
+
+    private static String orUnspecified(String value) {
+        return value == null || value.isEmpty() ? UNSPECIFIED_ID_PART : value;
+    }
+
     public static void saveToFileAsJson(File outputFile, GradleDepTreeResults results) {
         try (FileWriter fileWriter = new FileWriter(outputFile);
              Writer writer = new BufferedWriter(fileWriter)) {

--- a/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
+++ b/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
@@ -213,16 +213,22 @@ public class GenerateDepTrees extends DefaultTask {
         ConfigurationContainer configsContainer = project.getConfigurations();
         Set<String> names = new HashSet<>(configsContainer.getNames());
         for (String name : names) {
-            addConfiguration(root, configsContainer.getByName(name), nodes);
+            // Thread `project` through so GradleDependencyTreeUtils.synthesizeProjectNodeId can
+            // look up sibling subprojects when a project dep's ResolvedComponentResult returns
+            // a null ModuleVersionIdentifier — required for the synthesized id to match this
+            // class's getProjectModuleId(), without which per-subproject tree files won't
+            // merge correctly downstream (jf curation-audit reports a fraction of the real
+            // blocked-package signal). See Utils.UNSPECIFIED_ID_PART for the centralisation
+            // invariant the lookup enforces.
+            addConfiguration(project, root, configsContainer.getByName(name), nodes);
         }
         return new GradleDepTreeResults(rootId, nodes);
     }
 
     private String getProjectModuleId(Project project) {
-        final String unspecifiedIdPart = "unspecified";
-        String group = project.getGroup().toString().isEmpty() ? unspecifiedIdPart : project.getGroup().toString();
-        String name = project.getName().isEmpty() ? unspecifiedIdPart : project.getName();
-        String version = project.getVersion().toString().isEmpty() ? unspecifiedIdPart : project.getVersion().toString();
-        return String.join(":", group, name, version);
+        return Utils.buildModuleId(
+                project.getGroup().toString(),
+                project.getName(),
+                project.getVersion().toString());
     }
 }

--- a/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
+++ b/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
@@ -213,13 +213,8 @@ public class GenerateDepTrees extends DefaultTask {
         ConfigurationContainer configsContainer = project.getConfigurations();
         Set<String> names = new HashSet<>(configsContainer.getNames());
         for (String name : names) {
-            // Thread `project` through so GradleDependencyTreeUtils.synthesizeProjectNodeId can
-            // look up sibling subprojects when a project dep's ResolvedComponentResult returns
-            // a null ModuleVersionIdentifier — required for the synthesized id to match this
-            // class's getProjectModuleId(), without which per-subproject tree files won't
-            // merge correctly downstream (jf curation-audit reports a fraction of the real
-            // blocked-package signal). See Utils.UNSPECIFIED_ID_PART for the centralisation
-            // invariant the lookup enforces.
+            // Pass `project` so synthesizeProjectNodeId can resolve sibling subprojects
+            // (keeps synthesized ids aligned with getProjectModuleId).
             addConfiguration(project, root, configsContainer.getByName(name), nodes);
         }
         return new GradleDepTreeResults(rootId, nodes);

--- a/src/test/java/com/jfrog/GradleDependencyTreeUtilsTest.java
+++ b/src/test/java/com/jfrog/GradleDependencyTreeUtilsTest.java
@@ -64,11 +64,6 @@ public class GradleDependencyTreeUtilsTest {
         assertFalse(nodes.get("child-2").isUnresolved());
     }
 
-    /**
-     * External dep with a non-null {@link ModuleVersionIdentifier} → preserve the original
-     * "group:name:version" id format. The Project lookup path is not exercised here because
-     * the synthesizer is only called when {@code getModuleVersion()} is null.
-     */
     @Test
     public void testResolveNodeId_externalModule_returnsModuleVersionString() {
         ModuleVersionIdentifier mvId = mock(ModuleVersionIdentifier.class);
@@ -80,13 +75,6 @@ public class GradleDependencyTreeUtilsTest {
         assertEquals(resolveNodeId(null, component), "com.itextpdf:kernel:7.2.5");
     }
 
-    /**
-     * Project dep without {@code group}/{@code version} configured → {@code getModuleVersion()}
-     * is {@code null}. With a {@code null} ownerProject the synthesizer falls back to a
-     * path-based id; with a real ownerProject it would mirror {@code getProjectModuleId} via
-     * {@link Project#findProject(String)} (covered by
-     * {@link #testSynthesizeProjectNodeId_resolvableSubproject_matchesGetProjectModuleId}).
-     */
     @Test
     public void testResolveNodeId_projectDepWithNullModuleVersion_synthesizesId() {
         ProjectComponentIdentifier id = mock(ProjectComponentIdentifier.class);
@@ -96,16 +84,13 @@ public class GradleDependencyTreeUtilsTest {
         when(component.getModuleVersion()).thenReturn(null);
         when(component.getId()).thenReturn(id);
 
+        // Null ownerProject → fallback path-based id.
         assertEquals(resolveNodeId(null, component), "unspecified:DummyService:unspecified");
     }
 
-    /**
-     * Genuine "not in any repository" case: external module that failed to resolve.
-     * Must continue to return null (preserves original drop-the-subtree behaviour), since
-     * we have nothing to identify it by.
-     */
     @Test
     public void testResolveNodeId_externalModuleWithNullModuleVersion_returnsNull() {
+        // External dep that failed to resolve: no ProjectComponentIdentifier, no fallback.
         ModuleComponentIdentifier id = mock(ModuleComponentIdentifier.class);
 
         ResolvedComponentResult component = mock(ResolvedComponentResult.class);
@@ -124,7 +109,6 @@ public class GradleDependencyTreeUtilsTest {
 
     @Test
     public void testSynthesizeProjectNodeId_nestedPath_usesLastSegment() {
-        // Mirrors GenerateDepTrees#getProjectModuleId, which uses Project.getName().
         ProjectComponentIdentifier id = mock(ProjectComponentIdentifier.class);
         when(id.getProjectPath()).thenReturn(":services:webservice");
         assertEquals(synthesizeProjectNodeId(null, id), "unspecified:webservice:unspecified");
@@ -144,13 +128,9 @@ public class GradleDependencyTreeUtilsTest {
         assertEquals(synthesizeProjectNodeId(null, id), "unspecified:unspecified:unspecified");
     }
 
-    /**
-     * Subproject lookup miss (e.g. cross-build / included-build references where
-     * {@link Project#findProject(String)} returns {@code null}) must fall through to the
-     * path-based fallback rather than NPE.
-     */
     @Test
     public void testSynthesizeProjectNodeId_ownerCannotResolvePath_usesFallback() {
+        // Cross-build / included-build refs: findProject returns null → fallback, not NPE.
         Project ownerProject = mock(Project.class);
         when(ownerProject.findProject(":externalBuild:lib")).thenReturn(null);
 
@@ -161,25 +141,13 @@ public class GradleDependencyTreeUtilsTest {
     }
 
     /**
-     * THE invariant test — the one that should have caught the original bug.
-     * <p>
-     * When the ownerProject can resolve the project path (the common case for project deps
-     * in the same build), the synthesized id MUST match what {@code GenerateDepTrees#getProjectModuleId}
-     * would produce for the same subproject. Otherwise the parent's tree references project
-     * deps under one key and the child's own tree file is rooted under a different key —
-     * downstream merging breaks and consumers like {@code jf curation-audit} report only a
-     * fraction of the real blocked-package signal (this is exactly what the customer who
-     * surfaced the original bug saw: 33 blocked packages → 3, all 30 missing deps reachable
-     * only via project-dep chains where the merge silently failed).
-     * <p>
-     * The mock subproject mirrors stock Gradle's default group-derivation for a top-level
-     * subproject of root project {@code skyscraper}: group={@code "skyscraper"} (root project's
-     * name), version={@code "unspecified"} ({@code Project.DEFAULT_VERSION}).
+     * Centralisation invariant: when ownerProject can resolve the path, the synthesized id
+     * MUST equal {@code GenerateDepTrees#getProjectModuleId}'s output for the same subproject.
      */
     @Test
     public void testSynthesizeProjectNodeId_resolvableSubproject_matchesGetProjectModuleId() {
         Project subproject = mock(Project.class);
-        // Project.getGroup() / getVersion() return Object (Mockito accepts a String here).
+        // getGroup()/getVersion() return Object — doReturn lets Mockito accept the String.
         doReturn("skyscraper").when(subproject).getGroup();
         when(subproject.getName()).thenReturn("DummyService");
         doReturn("unspecified").when(subproject).getVersion();
@@ -191,35 +159,20 @@ public class GradleDependencyTreeUtilsTest {
         when(id.getProjectPath()).thenReturn(":DummyService");
 
         String synthesized = synthesizeProjectNodeId(ownerProject, id);
-
-        // Hard assertion against the literal expected id...
         assertEquals(synthesized, "skyscraper:DummyService:unspecified",
                 "Synthesized id must match GenerateDepTrees#getProjectModuleId for the same subproject "
                         + "— without this, per-subproject tree files don't merge downstream and "
                         + "consumers see only a fraction of blocked packages.");
-        // ...and the centralisation guarantee: must equal what buildModuleId with the same
-        // inputs would produce. If a future change re-inlines String.join or "unspecified"
-        // at either id-producing site, this assertion will fail.
         assertEquals(synthesized, com.jfrog.Utils.buildModuleId("skyscraper", "DummyService", "unspecified"));
     }
 
     /**
-     * End-to-end regression for the project-dep null-moduleVersion bug — fallback path
-     * (ownerProject {@code null}, so the synthesized id uses path-based placeholders).
-     * <p>
-     * Configuration shaped as {@code root → :middle (project, no module version) →
-     * com.itextpdf:kernel:7.2.5}. Pre-fix, {@code populateTree} returned early at
-     * {@code :middle} because its {@link ModuleVersionIdentifier} was {@code null},
-     * dropping {@code itextpdf:kernel} from the tree entirely. With the fix, the project
-     * dep gets a synthesized id and the transitive {@code itextpdf:kernel} appears in the
-     * resulting nodes map. The companion test
-     * {@link #testAddConfiguration_chainOfProjectDepsWithoutModuleVersion_resolvableOwner_matchesGetProjectModuleId}
-     * exercises the same chain with a real ownerProject and verifies the synthesized id
-     * matches {@code getProjectModuleId} (the centralisation invariant).
+     * End-to-end: chain {@code root → :middle (no module version) → com.itextpdf:kernel}.
+     * Pre-fix, populateTree returned early at :middle and dropped kernel. Fallback path here
+     * (null ownerProject) — synthesized id uses placeholder group/version.
      */
     @Test
     public void testAddConfiguration_chainOfProjectDepsWithoutModuleVersion_preservesTransitives() {
-        // Leaf: external Maven dep com.itextpdf:kernel:7.2.5 (well-formed module version).
         ModuleVersionIdentifier itextMv = mock(ModuleVersionIdentifier.class);
         when(itextMv.toString()).thenReturn("com.itextpdf:kernel:7.2.5");
         ResolvedComponentResult itextComponent = mock(ResolvedComponentResult.class);
@@ -229,7 +182,6 @@ public class GradleDependencyTreeUtilsTest {
         ResolvedDependencyResult itextDep = mock(ResolvedDependencyResult.class);
         when(itextDep.getSelected()).thenReturn(itextComponent);
 
-        // Middle: project dep :middle, no module version, transitively pulls in itextpdf:kernel.
         ProjectComponentIdentifier middleId = mock(ProjectComponentIdentifier.class);
         when(middleId.getProjectPath()).thenReturn(":middle");
 
@@ -241,7 +193,6 @@ public class GradleDependencyTreeUtilsTest {
         ResolvedDependencyResult middleDep = mock(ResolvedDependencyResult.class);
         when(middleDep.getSelected()).thenReturn(middleComponent);
 
-        // Root: configuration root component with one direct dep (the :middle project).
         ResolvedComponentResult rootComponent = mock(ResolvedComponentResult.class);
         doReturn(setOf(middleDep)).when(rootComponent).getDependencies();
 
@@ -260,43 +211,26 @@ public class GradleDependencyTreeUtilsTest {
         Map<String, GradleDependencyNode> nodes = new HashMap<>();
         nodes.put("root", root);
 
-        // Fallback path: no ownerProject for the synthesizer to resolve through.
         addConfiguration(null, root, configuration, nodes);
 
-        // The chain must survive: both :middle (synthesized) and com.itextpdf:kernel must appear.
         assertTrue(nodes.containsKey("unspecified:middle:unspecified"),
                 "Synthesized project node id is missing — populateTree dropped the project dep.");
         assertTrue(nodes.containsKey("com.itextpdf:kernel:7.2.5"),
                 "Transitive external dep is missing — chain was broken at the project dep "
                         + "(this is the original bug — null moduleVersion on the project dep "
                         + "caused early-return that dropped the entire subtree below it).");
-
-        // Topology: root → :middle → kernel.
         assertTrue(root.getChildren().contains("unspecified:middle:unspecified"));
         assertTrue(nodes.get("unspecified:middle:unspecified").getChildren()
                 .contains("com.itextpdf:kernel:7.2.5"));
     }
 
     /**
-     * End-to-end regression for the SECOND bug (the one that left the customer at 3-of-33
-     * blocked packages even after the first patch shipped).
-     * <p>
-     * Same chain as
-     * {@link #testAddConfiguration_chainOfProjectDepsWithoutModuleVersion_preservesTransitives},
-     * but with a real ownerProject whose {@link Project#findProject(String)} resolves
-     * {@code :middle} to a subproject mock that mirrors stock Gradle's default group/version
-     * derivation (group=root project name {@code "skyscraper"}, version={@code "unspecified"}).
-     * <p>
-     * Crucially, the synthesized middle-node id MUST be {@code "skyscraper:middle:unspecified"}
-     * — the same string {@code GenerateDepTrees#getProjectModuleId} would produce when generating
-     * {@code :middle}'s own dependency-tree file. If the id is anything else (most notably the
-     * fallback {@code "unspecified:middle:unspecified"}), per-subproject tree files don't merge
-     * downstream and consumers like {@code jf curation-audit} report a fraction of the real
-     * blocked-package signal.
+     * Same chain as above but with a resolvable ownerProject — the synthesized middle id
+     * must match getProjectModuleId ({@code "skyscraper:middle:unspecified"}), not the
+     * fallback ({@code "unspecified:middle:unspecified"}).
      */
     @Test
     public void testAddConfiguration_chainOfProjectDepsWithoutModuleVersion_resolvableOwner_matchesGetProjectModuleId() {
-        // Leaf: external Maven dep com.itextpdf:kernel:7.2.5 (well-formed module version).
         ModuleVersionIdentifier itextMv = mock(ModuleVersionIdentifier.class);
         when(itextMv.toString()).thenReturn("com.itextpdf:kernel:7.2.5");
         ResolvedComponentResult itextComponent = mock(ResolvedComponentResult.class);
@@ -306,7 +240,6 @@ public class GradleDependencyTreeUtilsTest {
         ResolvedDependencyResult itextDep = mock(ResolvedDependencyResult.class);
         when(itextDep.getSelected()).thenReturn(itextComponent);
 
-        // Middle: project dep :middle, no module version, transitively pulls in itextpdf:kernel.
         ProjectComponentIdentifier middleId = mock(ProjectComponentIdentifier.class);
         when(middleId.getProjectPath()).thenReturn(":middle");
 
@@ -332,8 +265,7 @@ public class GradleDependencyTreeUtilsTest {
         when(configuration.getName()).thenReturn("implementation");
         when(configuration.getIncoming()).thenReturn(incoming);
 
-        // ownerProject — the project whose configuration we're walking. findProject(":middle")
-        // returns a subproject mock with stock Gradle default group/version derivation.
+        // Subproject mirrors stock Gradle default derivation: group = root project name.
         Project middleSubproject = mock(Project.class);
         doReturn("skyscraper").when(middleSubproject).getGroup();
         when(middleSubproject.getName()).thenReturn("middle");
@@ -348,7 +280,6 @@ public class GradleDependencyTreeUtilsTest {
 
         addConfiguration(ownerProject, root, configuration, nodes);
 
-        // Centralisation invariant: synthesized id == GenerateDepTrees#getProjectModuleId.
         assertTrue(nodes.containsKey("skyscraper:middle:unspecified"),
                 "Synthesized middle id must equal getProjectModuleId's output ('skyscraper:middle:unspecified'); "
                         + "found nodes: " + nodes.keySet() + ". This is the cross-site centralisation invariant — "
@@ -356,18 +287,12 @@ public class GradleDependencyTreeUtilsTest {
         assertFalse(nodes.containsKey("unspecified:middle:unspecified"),
                 "Found fallback id 'unspecified:middle:unspecified' even though ownerProject could resolve "
                         + "the subproject — synthesizer is not consulting Project.findProject(path).");
-
-        // Topology: root → :middle (canonical id) → kernel.
         assertTrue(root.getChildren().contains("skyscraper:middle:unspecified"));
         assertTrue(nodes.get("skyscraper:middle:unspecified").getChildren()
                 .contains("com.itextpdf:kernel:7.2.5"));
     }
 
-    /**
-     * If a node truly has no usable identity (external dep with null module version and a
-     * non-project component identifier), it must still be skipped — same as the original
-     * "not in any repository" behaviour. Anything below it is unreachable anyway.
-     */
+    /** External dep with no module version and non-project id → still skipped (unreachable). */
     @Test
     public void testAddConfiguration_unresolvedExternalDepWithoutModuleVersion_isSkipped() {
         ComponentIdentifier nonProjectId = mock(ModuleComponentIdentifier.class);
@@ -406,14 +331,8 @@ public class GradleDependencyTreeUtilsTest {
     }
 
     /**
-     * Lock-in for the centralisation invariant: {@code addUnresolvedConfiguration} must route
-     * its id assembly through {@link com.jfrog.Utils#buildModuleId} so a {@code null} group on
-     * a declared dependency does not produce a literal {@code "null:foo:1.0"} node id (which
-     * the previous {@code String.join} code path produced).
-     * <p>
-     * This is a regression guard for the third id-producing site in the codebase — the other
-     * two ({@code GenerateDepTrees#getProjectModuleId} and {@code synthesizeProjectNodeId})
-     * already share the helper.
+     * addUnresolvedConfiguration must route through Utils.buildModuleId so a null group
+     * produces "unspecified:foo:1.0" rather than the literal "null:foo:1.0".
      */
     @Test
     public void testAddConfiguration_unresolvedDepWithNullGroup_usesUnspecifiedPlaceholder() {
@@ -423,8 +342,7 @@ public class GradleDependencyTreeUtilsTest {
         when(dep.getVersion()).thenReturn("1.0");
 
         DependencySet depSet = mock(DependencySet.class);
-        // DependencySet extends Iterable<Dependency> — the for-each in addUnresolvedConfiguration
-        // calls iterator() on it. A fresh iterator is needed per call.
+        // Fresh iterator per call — DependencySet's for-each in addUnresolvedConfiguration calls iterator().
         when(depSet.iterator()).thenAnswer(invocation -> Collections.singletonList(dep).iterator());
 
         Configuration configuration = mock(Configuration.class);
@@ -435,8 +353,6 @@ public class GradleDependencyTreeUtilsTest {
         GradleDependencyNode root = new GradleDependencyNode();
         Map<String, GradleDependencyNode> nodes = new HashMap<>();
 
-        // ownerProject is irrelevant for unresolved-config flow (no project deps, no
-        // synthesizer invocation), so passing null is correct here.
         addConfiguration(null, root, configuration, nodes);
 
         assertTrue(nodes.containsKey("unspecified:foo:1.0"),
@@ -448,11 +364,6 @@ public class GradleDependencyTreeUtilsTest {
         assertTrue(root.getChildren().contains("unspecified:foo:1.0"));
     }
 
-    /**
-     * Belt-and-braces: when the unresolved dependency has fully-populated coordinates, the
-     * id must be unchanged (i.e. centralisation via {@code buildModuleId} is a no-op for the
-     * common case).
-     */
     @Test
     public void testAddConfiguration_unresolvedDepWithAllCoordinates_preservesId() {
         Dependency dep = mock(Dependency.class);
@@ -479,10 +390,7 @@ public class GradleDependencyTreeUtilsTest {
                 "Unresolved-config children must be flagged unresolved.");
     }
 
-    /**
-     * Pre-existing behaviour preserved: dependencies with a {@code null} version — typically
-     * {@code implementation gradleApi()} or similar — are skipped entirely (have no usable id).
-     */
+    /** Pre-existing: deps with no version (e.g. gradleApi()) are skipped. */
     @Test
     public void testAddConfiguration_unresolvedDepWithNullVersion_isSkipped() {
         Dependency dep = mock(Dependency.class);

--- a/src/test/java/com/jfrog/GradleDependencyTreeUtilsTest.java
+++ b/src/test/java/com/jfrog/GradleDependencyTreeUtilsTest.java
@@ -1,12 +1,34 @@
 package com.jfrog;
 
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencySet;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolvableDependencies;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.artifacts.result.DependencyResult;
+import org.gradle.api.artifacts.result.ResolutionResult;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.testng.annotations.Test;
 import org.testng.collections.Sets;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static com.jfrog.GradleDependencyTreeUtils.addChild;
+import static com.jfrog.GradleDependencyTreeUtils.addConfiguration;
+import static com.jfrog.GradleDependencyTreeUtils.resolveNodeId;
+import static com.jfrog.GradleDependencyTreeUtils.synthesizeProjectNodeId;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
 public class GradleDependencyTreeUtilsTest {
@@ -40,5 +62,455 @@ public class GradleDependencyTreeUtilsTest {
         assertEquals(dep.getChildren().size(), 2);
         assertEquals(nodes.get("child-2").getConfigurations(), Sets.newHashSet("configuration-1"));
         assertFalse(nodes.get("child-2").isUnresolved());
+    }
+
+    /**
+     * External dep with a non-null {@link ModuleVersionIdentifier} → preserve the original
+     * "group:name:version" id format. The Project lookup path is not exercised here because
+     * the synthesizer is only called when {@code getModuleVersion()} is null.
+     */
+    @Test
+    public void testResolveNodeId_externalModule_returnsModuleVersionString() {
+        ModuleVersionIdentifier mvId = mock(ModuleVersionIdentifier.class);
+        when(mvId.toString()).thenReturn("com.itextpdf:kernel:7.2.5");
+
+        ResolvedComponentResult component = mock(ResolvedComponentResult.class);
+        when(component.getModuleVersion()).thenReturn(mvId);
+
+        assertEquals(resolveNodeId(null, component), "com.itextpdf:kernel:7.2.5");
+    }
+
+    /**
+     * Project dep without {@code group}/{@code version} configured → {@code getModuleVersion()}
+     * is {@code null}. With a {@code null} ownerProject the synthesizer falls back to a
+     * path-based id; with a real ownerProject it would mirror {@code getProjectModuleId} via
+     * {@link Project#findProject(String)} (covered by
+     * {@link #testSynthesizeProjectNodeId_resolvableSubproject_matchesGetProjectModuleId}).
+     */
+    @Test
+    public void testResolveNodeId_projectDepWithNullModuleVersion_synthesizesId() {
+        ProjectComponentIdentifier id = mock(ProjectComponentIdentifier.class);
+        when(id.getProjectPath()).thenReturn(":DummyService");
+
+        ResolvedComponentResult component = mock(ResolvedComponentResult.class);
+        when(component.getModuleVersion()).thenReturn(null);
+        when(component.getId()).thenReturn(id);
+
+        assertEquals(resolveNodeId(null, component), "unspecified:DummyService:unspecified");
+    }
+
+    /**
+     * Genuine "not in any repository" case: external module that failed to resolve.
+     * Must continue to return null (preserves original drop-the-subtree behaviour), since
+     * we have nothing to identify it by.
+     */
+    @Test
+    public void testResolveNodeId_externalModuleWithNullModuleVersion_returnsNull() {
+        ModuleComponentIdentifier id = mock(ModuleComponentIdentifier.class);
+
+        ResolvedComponentResult component = mock(ResolvedComponentResult.class);
+        when(component.getModuleVersion()).thenReturn(null);
+        when(component.getId()).thenReturn(id);
+
+        assertNull(resolveNodeId(null, component));
+    }
+
+    @Test
+    public void testSynthesizeProjectNodeId_simplePath_nullOwner_usesFallback() {
+        ProjectComponentIdentifier id = mock(ProjectComponentIdentifier.class);
+        when(id.getProjectPath()).thenReturn(":lib");
+        assertEquals(synthesizeProjectNodeId(null, id), "unspecified:lib:unspecified");
+    }
+
+    @Test
+    public void testSynthesizeProjectNodeId_nestedPath_usesLastSegment() {
+        // Mirrors GenerateDepTrees#getProjectModuleId, which uses Project.getName().
+        ProjectComponentIdentifier id = mock(ProjectComponentIdentifier.class);
+        when(id.getProjectPath()).thenReturn(":services:webservice");
+        assertEquals(synthesizeProjectNodeId(null, id), "unspecified:webservice:unspecified");
+    }
+
+    @Test
+    public void testSynthesizeProjectNodeId_rootPath_fallsBackToUnspecifiedName() {
+        ProjectComponentIdentifier id = mock(ProjectComponentIdentifier.class);
+        when(id.getProjectPath()).thenReturn(":");
+        assertEquals(synthesizeProjectNodeId(null, id), "unspecified:unspecified:unspecified");
+    }
+
+    @Test
+    public void testSynthesizeProjectNodeId_nullPath_fallsBackToAllUnspecified() {
+        ProjectComponentIdentifier id = mock(ProjectComponentIdentifier.class);
+        when(id.getProjectPath()).thenReturn(null);
+        assertEquals(synthesizeProjectNodeId(null, id), "unspecified:unspecified:unspecified");
+    }
+
+    /**
+     * Subproject lookup miss (e.g. cross-build / included-build references where
+     * {@link Project#findProject(String)} returns {@code null}) must fall through to the
+     * path-based fallback rather than NPE.
+     */
+    @Test
+    public void testSynthesizeProjectNodeId_ownerCannotResolvePath_usesFallback() {
+        Project ownerProject = mock(Project.class);
+        when(ownerProject.findProject(":externalBuild:lib")).thenReturn(null);
+
+        ProjectComponentIdentifier id = mock(ProjectComponentIdentifier.class);
+        when(id.getProjectPath()).thenReturn(":externalBuild:lib");
+
+        assertEquals(synthesizeProjectNodeId(ownerProject, id), "unspecified:lib:unspecified");
+    }
+
+    /**
+     * THE invariant test — the one that should have caught the original bug.
+     * <p>
+     * When the ownerProject can resolve the project path (the common case for project deps
+     * in the same build), the synthesized id MUST match what {@code GenerateDepTrees#getProjectModuleId}
+     * would produce for the same subproject. Otherwise the parent's tree references project
+     * deps under one key and the child's own tree file is rooted under a different key —
+     * downstream merging breaks and consumers like {@code jf curation-audit} report only a
+     * fraction of the real blocked-package signal (this is exactly what the customer who
+     * surfaced the original bug saw: 33 blocked packages → 3, all 30 missing deps reachable
+     * only via project-dep chains where the merge silently failed).
+     * <p>
+     * The mock subproject mirrors stock Gradle's default group-derivation for a top-level
+     * subproject of root project {@code skyscraper}: group={@code "skyscraper"} (root project's
+     * name), version={@code "unspecified"} ({@code Project.DEFAULT_VERSION}).
+     */
+    @Test
+    public void testSynthesizeProjectNodeId_resolvableSubproject_matchesGetProjectModuleId() {
+        Project subproject = mock(Project.class);
+        // Project.getGroup() / getVersion() return Object (Mockito accepts a String here).
+        doReturn("skyscraper").when(subproject).getGroup();
+        when(subproject.getName()).thenReturn("DummyService");
+        doReturn("unspecified").when(subproject).getVersion();
+
+        Project ownerProject = mock(Project.class);
+        when(ownerProject.findProject(":DummyService")).thenReturn(subproject);
+
+        ProjectComponentIdentifier id = mock(ProjectComponentIdentifier.class);
+        when(id.getProjectPath()).thenReturn(":DummyService");
+
+        String synthesized = synthesizeProjectNodeId(ownerProject, id);
+
+        // Hard assertion against the literal expected id...
+        assertEquals(synthesized, "skyscraper:DummyService:unspecified",
+                "Synthesized id must match GenerateDepTrees#getProjectModuleId for the same subproject "
+                        + "— without this, per-subproject tree files don't merge downstream and "
+                        + "consumers see only a fraction of blocked packages.");
+        // ...and the centralisation guarantee: must equal what buildModuleId with the same
+        // inputs would produce. If a future change re-inlines String.join or "unspecified"
+        // at either id-producing site, this assertion will fail.
+        assertEquals(synthesized, com.jfrog.Utils.buildModuleId("skyscraper", "DummyService", "unspecified"));
+    }
+
+    /**
+     * End-to-end regression for the project-dep null-moduleVersion bug — fallback path
+     * (ownerProject {@code null}, so the synthesized id uses path-based placeholders).
+     * <p>
+     * Configuration shaped as {@code root → :middle (project, no module version) →
+     * com.itextpdf:kernel:7.2.5}. Pre-fix, {@code populateTree} returned early at
+     * {@code :middle} because its {@link ModuleVersionIdentifier} was {@code null},
+     * dropping {@code itextpdf:kernel} from the tree entirely. With the fix, the project
+     * dep gets a synthesized id and the transitive {@code itextpdf:kernel} appears in the
+     * resulting nodes map. The companion test
+     * {@link #testAddConfiguration_chainOfProjectDepsWithoutModuleVersion_resolvableOwner_matchesGetProjectModuleId}
+     * exercises the same chain with a real ownerProject and verifies the synthesized id
+     * matches {@code getProjectModuleId} (the centralisation invariant).
+     */
+    @Test
+    public void testAddConfiguration_chainOfProjectDepsWithoutModuleVersion_preservesTransitives() {
+        // Leaf: external Maven dep com.itextpdf:kernel:7.2.5 (well-formed module version).
+        ModuleVersionIdentifier itextMv = mock(ModuleVersionIdentifier.class);
+        when(itextMv.toString()).thenReturn("com.itextpdf:kernel:7.2.5");
+        ResolvedComponentResult itextComponent = mock(ResolvedComponentResult.class);
+        when(itextComponent.getModuleVersion()).thenReturn(itextMv);
+        doReturn(Collections.emptySet()).when(itextComponent).getDependencies();
+
+        ResolvedDependencyResult itextDep = mock(ResolvedDependencyResult.class);
+        when(itextDep.getSelected()).thenReturn(itextComponent);
+
+        // Middle: project dep :middle, no module version, transitively pulls in itextpdf:kernel.
+        ProjectComponentIdentifier middleId = mock(ProjectComponentIdentifier.class);
+        when(middleId.getProjectPath()).thenReturn(":middle");
+
+        ResolvedComponentResult middleComponent = mock(ResolvedComponentResult.class);
+        when(middleComponent.getModuleVersion()).thenReturn(null);
+        when(middleComponent.getId()).thenReturn(middleId);
+        doReturn(setOf(itextDep)).when(middleComponent).getDependencies();
+
+        ResolvedDependencyResult middleDep = mock(ResolvedDependencyResult.class);
+        when(middleDep.getSelected()).thenReturn(middleComponent);
+
+        // Root: configuration root component with one direct dep (the :middle project).
+        ResolvedComponentResult rootComponent = mock(ResolvedComponentResult.class);
+        doReturn(setOf(middleDep)).when(rootComponent).getDependencies();
+
+        ResolutionResult resolutionResult = mock(ResolutionResult.class);
+        when(resolutionResult.getRoot()).thenReturn(rootComponent);
+
+        ResolvableDependencies incoming = mock(ResolvableDependencies.class);
+        when(incoming.getResolutionResult()).thenReturn(resolutionResult);
+
+        Configuration configuration = mock(Configuration.class);
+        when(configuration.isCanBeResolved()).thenReturn(true);
+        when(configuration.getName()).thenReturn("implementation");
+        when(configuration.getIncoming()).thenReturn(incoming);
+
+        GradleDependencyNode root = new GradleDependencyNode();
+        Map<String, GradleDependencyNode> nodes = new HashMap<>();
+        nodes.put("root", root);
+
+        // Fallback path: no ownerProject for the synthesizer to resolve through.
+        addConfiguration(null, root, configuration, nodes);
+
+        // The chain must survive: both :middle (synthesized) and com.itextpdf:kernel must appear.
+        assertTrue(nodes.containsKey("unspecified:middle:unspecified"),
+                "Synthesized project node id is missing — populateTree dropped the project dep.");
+        assertTrue(nodes.containsKey("com.itextpdf:kernel:7.2.5"),
+                "Transitive external dep is missing — chain was broken at the project dep "
+                        + "(this is the original bug — null moduleVersion on the project dep "
+                        + "caused early-return that dropped the entire subtree below it).");
+
+        // Topology: root → :middle → kernel.
+        assertTrue(root.getChildren().contains("unspecified:middle:unspecified"));
+        assertTrue(nodes.get("unspecified:middle:unspecified").getChildren()
+                .contains("com.itextpdf:kernel:7.2.5"));
+    }
+
+    /**
+     * End-to-end regression for the SECOND bug (the one that left the customer at 3-of-33
+     * blocked packages even after the first patch shipped).
+     * <p>
+     * Same chain as
+     * {@link #testAddConfiguration_chainOfProjectDepsWithoutModuleVersion_preservesTransitives},
+     * but with a real ownerProject whose {@link Project#findProject(String)} resolves
+     * {@code :middle} to a subproject mock that mirrors stock Gradle's default group/version
+     * derivation (group=root project name {@code "skyscraper"}, version={@code "unspecified"}).
+     * <p>
+     * Crucially, the synthesized middle-node id MUST be {@code "skyscraper:middle:unspecified"}
+     * — the same string {@code GenerateDepTrees#getProjectModuleId} would produce when generating
+     * {@code :middle}'s own dependency-tree file. If the id is anything else (most notably the
+     * fallback {@code "unspecified:middle:unspecified"}), per-subproject tree files don't merge
+     * downstream and consumers like {@code jf curation-audit} report a fraction of the real
+     * blocked-package signal.
+     */
+    @Test
+    public void testAddConfiguration_chainOfProjectDepsWithoutModuleVersion_resolvableOwner_matchesGetProjectModuleId() {
+        // Leaf: external Maven dep com.itextpdf:kernel:7.2.5 (well-formed module version).
+        ModuleVersionIdentifier itextMv = mock(ModuleVersionIdentifier.class);
+        when(itextMv.toString()).thenReturn("com.itextpdf:kernel:7.2.5");
+        ResolvedComponentResult itextComponent = mock(ResolvedComponentResult.class);
+        when(itextComponent.getModuleVersion()).thenReturn(itextMv);
+        doReturn(Collections.emptySet()).when(itextComponent).getDependencies();
+
+        ResolvedDependencyResult itextDep = mock(ResolvedDependencyResult.class);
+        when(itextDep.getSelected()).thenReturn(itextComponent);
+
+        // Middle: project dep :middle, no module version, transitively pulls in itextpdf:kernel.
+        ProjectComponentIdentifier middleId = mock(ProjectComponentIdentifier.class);
+        when(middleId.getProjectPath()).thenReturn(":middle");
+
+        ResolvedComponentResult middleComponent = mock(ResolvedComponentResult.class);
+        when(middleComponent.getModuleVersion()).thenReturn(null);
+        when(middleComponent.getId()).thenReturn(middleId);
+        doReturn(setOf(itextDep)).when(middleComponent).getDependencies();
+
+        ResolvedDependencyResult middleDep = mock(ResolvedDependencyResult.class);
+        when(middleDep.getSelected()).thenReturn(middleComponent);
+
+        ResolvedComponentResult rootComponent = mock(ResolvedComponentResult.class);
+        doReturn(setOf(middleDep)).when(rootComponent).getDependencies();
+
+        ResolutionResult resolutionResult = mock(ResolutionResult.class);
+        when(resolutionResult.getRoot()).thenReturn(rootComponent);
+
+        ResolvableDependencies incoming = mock(ResolvableDependencies.class);
+        when(incoming.getResolutionResult()).thenReturn(resolutionResult);
+
+        Configuration configuration = mock(Configuration.class);
+        when(configuration.isCanBeResolved()).thenReturn(true);
+        when(configuration.getName()).thenReturn("implementation");
+        when(configuration.getIncoming()).thenReturn(incoming);
+
+        // ownerProject — the project whose configuration we're walking. findProject(":middle")
+        // returns a subproject mock with stock Gradle default group/version derivation.
+        Project middleSubproject = mock(Project.class);
+        doReturn("skyscraper").when(middleSubproject).getGroup();
+        when(middleSubproject.getName()).thenReturn("middle");
+        doReturn("unspecified").when(middleSubproject).getVersion();
+
+        Project ownerProject = mock(Project.class);
+        when(ownerProject.findProject(":middle")).thenReturn(middleSubproject);
+
+        GradleDependencyNode root = new GradleDependencyNode();
+        Map<String, GradleDependencyNode> nodes = new HashMap<>();
+        nodes.put("root", root);
+
+        addConfiguration(ownerProject, root, configuration, nodes);
+
+        // Centralisation invariant: synthesized id == GenerateDepTrees#getProjectModuleId.
+        assertTrue(nodes.containsKey("skyscraper:middle:unspecified"),
+                "Synthesized middle id must equal getProjectModuleId's output ('skyscraper:middle:unspecified'); "
+                        + "found nodes: " + nodes.keySet() + ". This is the cross-site centralisation invariant — "
+                        + "without it, per-subproject tree files don't merge downstream.");
+        assertFalse(nodes.containsKey("unspecified:middle:unspecified"),
+                "Found fallback id 'unspecified:middle:unspecified' even though ownerProject could resolve "
+                        + "the subproject — synthesizer is not consulting Project.findProject(path).");
+
+        // Topology: root → :middle (canonical id) → kernel.
+        assertTrue(root.getChildren().contains("skyscraper:middle:unspecified"));
+        assertTrue(nodes.get("skyscraper:middle:unspecified").getChildren()
+                .contains("com.itextpdf:kernel:7.2.5"));
+    }
+
+    /**
+     * If a node truly has no usable identity (external dep with null module version and a
+     * non-project component identifier), it must still be skipped — same as the original
+     * "not in any repository" behaviour. Anything below it is unreachable anyway.
+     */
+    @Test
+    public void testAddConfiguration_unresolvedExternalDepWithoutModuleVersion_isSkipped() {
+        ComponentIdentifier nonProjectId = mock(ModuleComponentIdentifier.class);
+
+        ResolvedComponentResult brokenComponent = mock(ResolvedComponentResult.class);
+        when(brokenComponent.getModuleVersion()).thenReturn(null);
+        when(brokenComponent.getId()).thenReturn(nonProjectId);
+        doReturn(Collections.emptySet()).when(brokenComponent).getDependencies();
+
+        ResolvedDependencyResult brokenDep = mock(ResolvedDependencyResult.class);
+        when(brokenDep.getSelected()).thenReturn(brokenComponent);
+
+        ResolvedComponentResult rootComponent = mock(ResolvedComponentResult.class);
+        doReturn(setOf(brokenDep)).when(rootComponent).getDependencies();
+
+        ResolutionResult resolutionResult = mock(ResolutionResult.class);
+        when(resolutionResult.getRoot()).thenReturn(rootComponent);
+
+        ResolvableDependencies incoming = mock(ResolvableDependencies.class);
+        when(incoming.getResolutionResult()).thenReturn(resolutionResult);
+
+        Configuration configuration = mock(Configuration.class);
+        when(configuration.isCanBeResolved()).thenReturn(true);
+        when(configuration.getName()).thenReturn("implementation");
+        when(configuration.getIncoming()).thenReturn(incoming);
+
+        GradleDependencyNode root = new GradleDependencyNode();
+        Map<String, GradleDependencyNode> nodes = new HashMap<>();
+        nodes.put("root", root);
+
+        addConfiguration(null, root, configuration, nodes);
+
+        // Root learns the configuration name but no orphaned child gets added.
+        assertTrue(root.getChildren().isEmpty());
+        assertEquals(nodes.size(), 1);
+    }
+
+    /**
+     * Lock-in for the centralisation invariant: {@code addUnresolvedConfiguration} must route
+     * its id assembly through {@link com.jfrog.Utils#buildModuleId} so a {@code null} group on
+     * a declared dependency does not produce a literal {@code "null:foo:1.0"} node id (which
+     * the previous {@code String.join} code path produced).
+     * <p>
+     * This is a regression guard for the third id-producing site in the codebase — the other
+     * two ({@code GenerateDepTrees#getProjectModuleId} and {@code synthesizeProjectNodeId})
+     * already share the helper.
+     */
+    @Test
+    public void testAddConfiguration_unresolvedDepWithNullGroup_usesUnspecifiedPlaceholder() {
+        Dependency dep = mock(Dependency.class);
+        when(dep.getGroup()).thenReturn(null);
+        when(dep.getName()).thenReturn("foo");
+        when(dep.getVersion()).thenReturn("1.0");
+
+        DependencySet depSet = mock(DependencySet.class);
+        // DependencySet extends Iterable<Dependency> — the for-each in addUnresolvedConfiguration
+        // calls iterator() on it. A fresh iterator is needed per call.
+        when(depSet.iterator()).thenAnswer(invocation -> Collections.singletonList(dep).iterator());
+
+        Configuration configuration = mock(Configuration.class);
+        when(configuration.isCanBeResolved()).thenReturn(false);
+        when(configuration.getName()).thenReturn("api");
+        when(configuration.getDependencies()).thenReturn(depSet);
+
+        GradleDependencyNode root = new GradleDependencyNode();
+        Map<String, GradleDependencyNode> nodes = new HashMap<>();
+
+        // ownerProject is irrelevant for unresolved-config flow (no project deps, no
+        // synthesizer invocation), so passing null is correct here.
+        addConfiguration(null, root, configuration, nodes);
+
+        assertTrue(nodes.containsKey("unspecified:foo:1.0"),
+                "Expected centralised 'unspecified:foo:1.0' node id, but found: " + nodes.keySet()
+                        + " — the addUnresolvedConfiguration site must use Utils.buildModuleId, "
+                        + "otherwise a null group falls back to the literal string 'null'.");
+        assertFalse(nodes.containsKey("null:foo:1.0"),
+                "Found legacy 'null:foo:1.0' key — the raw String.join regressed.");
+        assertTrue(root.getChildren().contains("unspecified:foo:1.0"));
+    }
+
+    /**
+     * Belt-and-braces: when the unresolved dependency has fully-populated coordinates, the
+     * id must be unchanged (i.e. centralisation via {@code buildModuleId} is a no-op for the
+     * common case).
+     */
+    @Test
+    public void testAddConfiguration_unresolvedDepWithAllCoordinates_preservesId() {
+        Dependency dep = mock(Dependency.class);
+        when(dep.getGroup()).thenReturn("com.example");
+        when(dep.getName()).thenReturn("foo");
+        when(dep.getVersion()).thenReturn("1.0");
+
+        DependencySet depSet = mock(DependencySet.class);
+        when(depSet.iterator()).thenAnswer(invocation -> Collections.singletonList(dep).iterator());
+
+        Configuration configuration = mock(Configuration.class);
+        when(configuration.isCanBeResolved()).thenReturn(false);
+        when(configuration.getName()).thenReturn("api");
+        when(configuration.getDependencies()).thenReturn(depSet);
+
+        GradleDependencyNode root = new GradleDependencyNode();
+        Map<String, GradleDependencyNode> nodes = new HashMap<>();
+
+        addConfiguration(null, root, configuration, nodes);
+
+        assertTrue(nodes.containsKey("com.example:foo:1.0"),
+                "Common-case id assembly must be unchanged. Nodes: " + nodes.keySet());
+        assertTrue(nodes.get("com.example:foo:1.0").isUnresolved(),
+                "Unresolved-config children must be flagged unresolved.");
+    }
+
+    /**
+     * Pre-existing behaviour preserved: dependencies with a {@code null} version — typically
+     * {@code implementation gradleApi()} or similar — are skipped entirely (have no usable id).
+     */
+    @Test
+    public void testAddConfiguration_unresolvedDepWithNullVersion_isSkipped() {
+        Dependency dep = mock(Dependency.class);
+        when(dep.getGroup()).thenReturn("foo");
+        when(dep.getName()).thenReturn("bar");
+        when(dep.getVersion()).thenReturn(null);
+
+        DependencySet depSet = mock(DependencySet.class);
+        when(depSet.iterator()).thenAnswer(invocation -> Collections.singletonList(dep).iterator());
+
+        Configuration configuration = mock(Configuration.class);
+        when(configuration.isCanBeResolved()).thenReturn(false);
+        when(configuration.getName()).thenReturn("api");
+        when(configuration.getDependencies()).thenReturn(depSet);
+
+        GradleDependencyNode root = new GradleDependencyNode();
+        Map<String, GradleDependencyNode> nodes = new HashMap<>();
+
+        addConfiguration(null, root, configuration, nodes);
+
+        assertTrue(root.getChildren().isEmpty(),
+                "Dependencies without a version must be skipped (gradleApi()-style).");
+        assertTrue(nodes.isEmpty());
+    }
+
+    private static <T extends DependencyResult> Set<DependencyResult> setOf(T item) {
+        Set<DependencyResult> set = new LinkedHashSet<>();
+        set.add(item);
+        return set;
     }
 }

--- a/src/test/java/com/jfrog/UtilsTest.java
+++ b/src/test/java/com/jfrog/UtilsTest.java
@@ -63,14 +63,9 @@ public class UtilsTest {
         assertEquals(actualOutput, expectedOutput);
     }
 
-    /**
-     * {@link Utils#buildModuleId} is the single source of truth for the
-     * {@code group:name:version} placeholder format used by both
-     * {@code GenerateDepTrees#getProjectModuleId} and
-     * {@code GradleDependencyTreeUtils#synthesizeProjectNodeId}. If these
-     * assertions ever change, both call sites need to be re-examined to keep
-     * downstream tree-merge logic consistent.
-     */
+    // buildModuleId is the single source of truth for the group:name:version placeholder
+    // format used by both GenerateDepTrees#getProjectModuleId and synthesizeProjectNodeId.
+
     @Test
     public void testBuildModuleId_allComponentsPresent() {
         assertEquals(buildModuleId("com.itextpdf", "kernel", "7.2.5"), "com.itextpdf:kernel:7.2.5");
@@ -103,7 +98,6 @@ public class UtilsTest {
 
     @Test
     public void testBuildModuleId_allNull_yieldsThreeUnspecifiedParts() {
-        // This is the value synthesizeProjectNodeId returns when the project path is null.
         assertEquals(buildModuleId(null, null, null),
                 String.join(":", UNSPECIFIED_ID_PART, UNSPECIFIED_ID_PART, UNSPECIFIED_ID_PART));
     }
@@ -114,13 +108,6 @@ public class UtilsTest {
                 String.join(":", UNSPECIFIED_ID_PART, UNSPECIFIED_ID_PART, UNSPECIFIED_ID_PART));
     }
 
-    /**
-     * Idempotence: passing {@code null} or {@code ""} for any part must produce the same id.
-     * If this ever drifts, sibling subprojects' tree files won't merge correctly downstream
-     * (the same subproject would be keyed differently depending on which API gave us the
-     * null-vs-empty value). The cross-site invariant proper — that the three id-producing
-     * call sites all agree — is locked down in {@code GradleDependencyTreeUtilsTest}.
-     */
     @Test
     public void testBuildModuleId_nullAndEmptyParts_areInterchangeable() {
         assertEquals(buildModuleId(null, "DummyService", null),

--- a/src/test/java/com/jfrog/UtilsTest.java
+++ b/src/test/java/com/jfrog/UtilsTest.java
@@ -14,6 +14,8 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.jfrog.Utils.UNSPECIFIED_ID_PART;
+import static com.jfrog.Utils.buildModuleId;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -59,5 +61,69 @@ public class UtilsTest {
         String expectedOutput = FileUtils.readFileToString(RESOURCES_DIR.resolve("expectedDepTree.json").toFile(), StandardCharsets.UTF_8).trim();
         String actualOutput = FileUtils.readFileToString(outputFile, StandardCharsets.UTF_8).trim();
         assertEquals(actualOutput, expectedOutput);
+    }
+
+    /**
+     * {@link Utils#buildModuleId} is the single source of truth for the
+     * {@code group:name:version} placeholder format used by both
+     * {@code GenerateDepTrees#getProjectModuleId} and
+     * {@code GradleDependencyTreeUtils#synthesizeProjectNodeId}. If these
+     * assertions ever change, both call sites need to be re-examined to keep
+     * downstream tree-merge logic consistent.
+     */
+    @Test
+    public void testBuildModuleId_allComponentsPresent() {
+        assertEquals(buildModuleId("com.itextpdf", "kernel", "7.2.5"), "com.itextpdf:kernel:7.2.5");
+    }
+
+    @Test
+    public void testBuildModuleId_nullGroup_replacedWithUnspecified() {
+        assertEquals(buildModuleId(null, "lib", "1.0"), UNSPECIFIED_ID_PART + ":lib:1.0");
+    }
+
+    @Test
+    public void testBuildModuleId_emptyGroup_replacedWithUnspecified() {
+        assertEquals(buildModuleId("", "lib", "1.0"), UNSPECIFIED_ID_PART + ":lib:1.0");
+    }
+
+    @Test
+    public void testBuildModuleId_nullName_replacedWithUnspecified() {
+        assertEquals(buildModuleId("com.example", null, "1.0"), "com.example:" + UNSPECIFIED_ID_PART + ":1.0");
+    }
+
+    @Test
+    public void testBuildModuleId_nullVersion_replacedWithUnspecified() {
+        assertEquals(buildModuleId("com.example", "lib", null), "com.example:lib:" + UNSPECIFIED_ID_PART);
+    }
+
+    @Test
+    public void testBuildModuleId_emptyVersion_replacedWithUnspecified() {
+        assertEquals(buildModuleId("com.example", "lib", ""), "com.example:lib:" + UNSPECIFIED_ID_PART);
+    }
+
+    @Test
+    public void testBuildModuleId_allNull_yieldsThreeUnspecifiedParts() {
+        // This is the value synthesizeProjectNodeId returns when the project path is null.
+        assertEquals(buildModuleId(null, null, null),
+                String.join(":", UNSPECIFIED_ID_PART, UNSPECIFIED_ID_PART, UNSPECIFIED_ID_PART));
+    }
+
+    @Test
+    public void testBuildModuleId_allEmpty_yieldsThreeUnspecifiedParts() {
+        assertEquals(buildModuleId("", "", ""),
+                String.join(":", UNSPECIFIED_ID_PART, UNSPECIFIED_ID_PART, UNSPECIFIED_ID_PART));
+    }
+
+    /**
+     * Idempotence: passing {@code null} or {@code ""} for any part must produce the same id.
+     * If this ever drifts, sibling subprojects' tree files won't merge correctly downstream
+     * (the same subproject would be keyed differently depending on which API gave us the
+     * null-vs-empty value). The cross-site invariant proper — that the three id-producing
+     * call sites all agree — is locked down in {@code GradleDependencyTreeUtilsTest}.
+     */
+    @Test
+    public void testBuildModuleId_nullAndEmptyParts_areInterchangeable() {
+        assertEquals(buildModuleId(null, "DummyService", null),
+                buildModuleId("", "DummyService", ""));
     }
 }


### PR DESCRIPTION
Fix dropped transitive deps under project(:foo) with null moduleVersion
`populateTree` returned early when `ResolvedComponentResult.getModuleVersion()` was null, silently dropping the entire transitive subtree under any local project dependency whose subproject did not declare `group`/`version`. Surfaced by `jf curation-audit` reporting 0 blocked packages while the native Gradle build failed with 403s on the same deps reachable only via a `project(":middle")` chain.

- Synthesize a fallback node id from `ProjectComponentIdentifier.getProjectPath()` for project deps with no module version, so recursion continues.
- Centralise the `group:name:version` placeholder format in `Utils.buildModuleId` / `Utils.UNSPECIFIED_ID_PART` and route all three id-producing call sites (`getProjectModuleId`, `synthesizeProjectNodeId`, `addUnresolvedConfiguration`) through it.
- Add Mockito-driven unit coverage for the null-moduleVersion path and a multi-module functional fixture as a happy-path regression guard.

Behaviour change: `addUnresolvedConfiguration` previously produced literal "null:foo:1.0" node ids when a declared dependency had a null group; it now produces "unspecified:foo:1.0", consistent with the other id-producing sites.

- [ ] All [tests](../CONTRIBUTING.md#tests) passed. If this feature is not already covered by the tests, I added new
  tests.

-----
