### PR TITLE
Fix Java Doc after changes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     testImplementation("commons-io:commons-io:2.14.0")
     testImplementation("org.testng:testng:7.7.1")
     testImplementation("org.mockito:mockito-core:4.11.0")
-    "functionalTestImplementation"("com.fasterxml.jackson.core:jackson-databind:2.16.0")
+    "functionalTestImplementation"("com.fasterxml.jackson.core:jackson-databind:2.18.6")
     "functionalTestImplementation"("commons-io:commons-io:2.14.0")
     "functionalTestImplementation"("org.testng:testng:7.7.1")
     "functionalTestImplementation"(project)

--- a/src/main/java/com/jfrog/GradleDependencyTreeUtils.java
+++ b/src/main/java/com/jfrog/GradleDependencyTreeUtils.java
@@ -78,7 +78,7 @@ public class GradleDependencyTreeUtils {
     /**
      * Recursively populate the dependency tree.
      *
-     * @param ownerProject      see {@link #addConfiguration} — passed unchanged through recursion
+     * @param ownerProject      see {@link #addConfiguration}; passed unchanged through recursion
      *                          so the project-dep synthesizer can look up sibling subprojects
      * @param node              the parent node
      * @param configurationName the configuration name
@@ -141,7 +141,7 @@ public class GradleDependencyTreeUtils {
      * <p>
      * If {@link Project#findProject(String)} resolves the path, use the subproject's actual
      * {@code group}/{@code name}/{@code version}. Otherwise (cross-build refs, lookup miss)
-     * fall back to a path-based id with {@link Utils#UNSPECIFIED_ID_PART} placeholders —
+     * fall back to a path-based id with {@link Utils#UNSPECIFIED_ID_PART} placeholders;
      * the chain survives, but the id won't merge cleanly with the child tree's root.
      */
     static String synthesizeProjectNodeId(Project ownerProject, ProjectComponentIdentifier id) {


### PR DESCRIPTION
- [ ] All [tests](../CONTRIBUTING.md#tests) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

Fixing the following error:

```
/home/runner/_work/ecosystem-workflows/ecosystem-workflows/gradle-dep-tree-release/src/main/java/com/jfrog/GradleDependencyTreeUtils.java:81: error: unmappable character (0xE2) for encoding US-ASCII
     * @param ownerProject      see {@link #addConfiguration} ??? passed unchanged through recursion

> Task :javadoc
                                                              ^
/home/runner/_work/ecosystem-workflows/ecosystem-workflows/gradle-dep-tree-release/src/main/java/com/jfrog/GradleDependencyTreeUtils.java:81: error: unmappable character (0x80) for encoding US-ASCII
     * @param ownerProject      see {@link #addConfiguration} ??? passed unchanged through recursion
                                                               ^
/home/runner/_work/ecosystem-workflows/ecosystem-workflows/gradle-dep-tree-release/src/main/java/com/jfrog/GradleDependencyTreeUtils.java:81: error: unmappable character (0x94) for encoding US-ASCII
     * @param ownerProject      see {@link #addConfiguration} ??? passed unchanged through recursion
                                                                ^
/home/runner/_work/ecosystem-workflows/ecosystem-workflows/gradle-dep-tree-release/src/main/java/com/jfrog/GradleDependencyTreeUtils.java:144: error: unmappable character (0xE2) for encoding US-ASCII
     * fall back to a path-based id with {@link Utils#UNSPECIFIED_ID_PART} placeholders ???
                                                                                        ^
/home/runner/_work/ecosystem-workflows/ecosystem-workflows/gradle-dep-tree-release/src/main/java/com/jfrog/GradleDependencyTreeUtils.java:144: error: unmappable character (0x80) for encoding US-ASCII
     * fall back to a path-based id with {@link Utils#UNSPECIFIED_ID_PART} placeholders ???
                                                                                         ^
/home/runner/_work/ecosystem-workflows/ecosystem-workflows/gradle-dep-tree-release/src/main/java/com/jfrog/GradleDependencyTreeUtils.java:144: error: unmappable character (0x94) for encoding US-ASCII
     * fall back to a path-based id with {@link Utils#UNSPECIFIED_ID_PART} placeholders ???
                                                                                          ^
6 errors

> Task :javadoc FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':javadoc'.
> Javadoc generation failed. Generated Javadoc options file (useful for troubleshooting): '/home/runner/_work/ecosystem-workflows/ecosystem-workflows/gradle-dep-tree-release/build/tmp/javadoc/javadoc.options'
```