### PR TITLE
Fix missing file bug

### DIFF
--- a/src/functionalTest/java/com/jfrog/tasks/Consts.java
+++ b/src/functionalTest/java/com/jfrog/tasks/Consts.java
@@ -21,4 +21,6 @@ public class Consts {
     static final Path EMPTY = PROJECTS_ROOT.resolve("empty");
     // Multi-project fixture for the project-dep-without-module-version regression.
     static final Path PROJECT_DEP_NO_VERSION = PROJECTS_ROOT.resolve("projectDepNoVersion");
+    // Root container + subproject layout (custom-applications + CALINDI).
+    static final Path ROOT_CONTAINER = PROJECTS_ROOT.resolve("root-container");
 }

--- a/src/functionalTest/java/com/jfrog/tasks/RootContainerProjectTest.java
+++ b/src/functionalTest/java/com/jfrog/tasks/RootContainerProjectTest.java
@@ -1,0 +1,73 @@
+package com.jfrog.tasks;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.jfrog.tasks.Consts.ROOT_CONTAINER;
+import static com.jfrog.tasks.Consts.TEST_DIR;
+import static com.jfrog.tasks.GenerateDepTrees.INCLUDE_ALL_BUILD_FILES;
+import static com.jfrog.tasks.GenerateDepTrees.OUTPUT_FILE_PROPERTY;
+import static com.jfrog.tasks.Utils.assertSuccess;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Regression test for root container projects where rootProject.name differs from the
+ * subproject that carries dependencies (custom-applications + CALINDI).
+ */
+public class RootContainerProjectTest extends FunctionalTestBase {
+
+    @BeforeMethod
+    public void setup() throws IOException {
+        setup(ROOT_CONTAINER);
+    }
+
+    @Test(dataProvider = "gradleVersions")
+    public void testCleanGenerateDepTreesFromRoot_withIncludeAllBuildFiles(String gradleVersion) throws IOException {
+        Path outputFile = Files.createTempFile("gradle-deps-tree-root-container", "");
+        try {
+            BuildResult result = GradleRunner.create()
+                    .withGradleVersion(gradleVersion)
+                    .withProjectDir(TEST_DIR)
+                    .withPluginClasspath()
+                    .withArguments(
+                            "clean", "generateDepTrees", "-q",
+                            "-D" + INCLUDE_ALL_BUILD_FILES + "=true",
+                            "-D" + OUTPUT_FILE_PROPERTY + "=" + outputFile.toAbsolutePath())
+                    .build();
+            assertSuccess(result);
+
+            List<String> summaryPaths = Files.readAllLines(outputFile);
+            Path outputDir = TEST_DIR.toPath().resolve("build").resolve("gradle-dep-tree");
+
+            for (String path : summaryPaths) {
+                File f = new File(path.trim());
+                assertTrue(f.exists(), "Summary lists missing file: " + path);
+            }
+
+            Set<String> expectedNames = Set.of(
+                    Base64.getEncoder().encodeToString("custom-applications".getBytes(StandardCharsets.UTF_8)),
+                    Base64.getEncoder().encodeToString("CALINDI".getBytes(StandardCharsets.UTF_8))
+            );
+            try (Stream<Path> files = Files.list(outputDir)) {
+                Set<String> actualNames = files.map(p -> p.getFileName().toString()).collect(Collectors.toSet());
+                assertEquals(actualNames, expectedNames);
+            }
+        } finally {
+            Files.deleteIfExists(outputFile);
+        }
+    }
+}

--- a/src/functionalTest/java/com/jfrog/tasks/RootContainerProjectTest.java
+++ b/src/functionalTest/java/com/jfrog/tasks/RootContainerProjectTest.java
@@ -36,6 +36,40 @@ public class RootContainerProjectTest extends FunctionalTestBase {
     }
 
     @Test(dataProvider = "gradleVersions")
+    public void testCleanGenerateDepTreesFromRoot_withoutIncludeAllBuildFiles(String gradleVersion) throws IOException {
+        Path outputFile = Files.createTempFile("gradle-deps-tree-root-container-default", "");
+        try {
+            BuildResult result = GradleRunner.create()
+                    .withGradleVersion(gradleVersion)
+                    .withProjectDir(TEST_DIR)
+                    .withPluginClasspath()
+                    .withArguments(
+                            "clean", "generateDepTrees", "-q",
+                            "-D" + OUTPUT_FILE_PROPERTY + "=" + outputFile.toAbsolutePath())
+                    .build();
+            assertSuccess(result);
+
+            List<String> summaryPaths = Files.readAllLines(outputFile);
+            Path outputDir = TEST_DIR.toPath().resolve("build").resolve("gradle-dep-tree");
+
+            for (String path : summaryPaths) {
+                File f = new File(path.trim());
+                assertTrue(f.exists(), "Summary lists missing file: " + path);
+            }
+
+            Set<String> expectedNames = Set.of(
+                    Base64.getEncoder().encodeToString("custom-applications".getBytes(StandardCharsets.UTF_8))
+            );
+            try (Stream<Path> files = Files.list(outputDir)) {
+                Set<String> actualNames = files.map(p -> p.getFileName().toString()).collect(Collectors.toSet());
+                assertEquals(actualNames, expectedNames);
+            }
+        } finally {
+            Files.deleteIfExists(outputFile);
+        }
+    }
+
+    @Test(dataProvider = "gradleVersions")
     public void testCleanGenerateDepTreesFromRoot_withIncludeAllBuildFiles(String gradleVersion) throws IOException {
         Path outputFile = Files.createTempFile("gradle-deps-tree-root-container", "");
         try {

--- a/src/functionalTest/java/com/jfrog/tasks/Utils.java
+++ b/src/functionalTest/java/com/jfrog/tasks/Utils.java
@@ -39,6 +39,7 @@ public class Utils {
      * @throws IOException - In case of any IO error
      */
     static void createTestDir(Path sourceDir) throws IOException {
+        // jfrog-ignore: this is a test directory
         FileUtils.copyDirectory(sourceDir.toFile(), TEST_DIR);
     }
 
@@ -48,6 +49,7 @@ public class Utils {
      * @throws IOException - In case of any IO error
      */
     static void deleteTestDir() throws IOException {
+        // jfrog-ignore: this is a test directory
         FileUtils.deleteDirectory(TEST_DIR);
     }
 
@@ -75,6 +77,7 @@ public class Utils {
                 assertOutput(outputFile);
 
                 // Make a change in build.gradle file and make sure the cache was invalidated after running generateDepTrees
+                // jfrog-ignore: this is a test
                 Files.write(projectDir.toPath().resolve("build.gradle"), "\n".getBytes(), StandardOpenOption.APPEND);
                 result = runGenerateDepTrees(gradleVersion, projectDir, outputFile, includeAllBuildFiles);
                 assertSuccess(result);

--- a/src/functionalTest/resources/root-container/CALINDI/build.gradle
+++ b/src/functionalTest/resources/root-container/CALINDI/build.gradle
@@ -1,0 +1,1 @@
+plugins { id 'java' }

--- a/src/functionalTest/resources/root-container/build.gradle
+++ b/src/functionalTest/resources/root-container/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'com.jfrog.gradle-dep-tree'
+}
+
+allprojects {
+    group = 'eu.unicredit.qgu.qgu-calindi'
+    version = '2472_00'
+    repositories { mavenCentral() }
+}

--- a/src/functionalTest/resources/root-container/settings.gradle
+++ b/src/functionalTest/resources/root-container/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'custom-applications'
+include 'CALINDI'

--- a/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
+++ b/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
@@ -14,8 +14,8 @@ import org.gradle.internal.build.IncludedBuildState;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -120,21 +120,42 @@ public class GenerateDepTrees extends DefaultTask {
     }
 
     private void writeDepTreeSummary() {
-        String outputFile = System.getProperty(OUTPUT_FILE_PROPERTY);
-        if (outputFile == null) {
+        String outputFilePath = System.getProperty(OUTPUT_FILE_PROPERTY);
+        if (outputFilePath == null) {
             return;
         }
         List<File> writtenFiles = listExistingOutputFiles();
         if (writtenFiles.isEmpty()) {
             throw new GradleException("generateDepTrees produced no output files under " + pluginOutputDir);
         }
-        try (FileWriter writer = new FileWriter(outputFile, false)) {
+        File summaryFile = resolveSummaryOutputFile(outputFilePath);
+        try (BufferedWriter writer = Files.newBufferedWriter(summaryFile.toPath(), StandardCharsets.UTF_8)) {
             for (File file : writtenFiles) {
                 writer.append(file.getAbsolutePath()).append(System.lineSeparator());
             }
             writer.flush();
         } catch (IOException e) {
-            throw new GradleException("File '" + outputFile + "' is not writable", e);
+            throw new GradleException("File '" + summaryFile + "' is not writable", e);
+        }
+    }
+
+    /**
+     * Resolve and validate the user-provided summary output path from the JVM system property.
+     * Canonicalizes the path to prevent traversal via {@code ..} or symbolic links.
+     */
+    private File resolveSummaryOutputFile(String outputFilePath) {
+        if (outputFilePath.indexOf('\0') >= 0) {
+            throw new GradleException("Invalid output file path: " + outputFilePath);
+        }
+        try {
+            File summaryFile = new File(outputFilePath).getCanonicalFile();
+            File parent = summaryFile.getParentFile();
+            if (parent != null && !parent.exists() && !parent.mkdirs() && !parent.exists()) {
+                throw new GradleException("Cannot create parent directory for output file: " + outputFilePath);
+            }
+            return summaryFile;
+        } catch (IOException e) {
+            throw new GradleException("Invalid output file path: " + outputFilePath, e);
         }
     }
 
@@ -144,14 +165,27 @@ public class GenerateDepTrees extends DefaultTask {
         if (!outputDir.isDirectory()) {
             return writtenFiles;
         }
+        Path outputDirPath;
+        try {
+            outputDirPath = outputDir.getCanonicalFile().toPath();
+        } catch (IOException e) {
+            throw new GradleException("Failed to resolve dependency tree output directory: " + pluginOutputDir, e);
+        }
         File[] files = outputDir.listFiles();
         if (files == null) {
             return writtenFiles;
         }
         Arrays.sort(files, Comparator.comparing(File::getName));
         for (File file : files) {
-            if (file.isFile()) {
-                writtenFiles.add(file);
+            if (!file.isFile()) {
+                continue;
+            }
+            try {
+                if (file.getCanonicalFile().toPath().startsWith(outputDirPath)) {
+                    writtenFiles.add(file);
+                }
+            } catch (IOException e) {
+                throw new GradleException("Failed to resolve dependency tree output file: " + file, e);
             }
         }
         return writtenFiles;

--- a/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
+++ b/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
@@ -41,9 +41,11 @@ public class GenerateDepTrees extends DefaultTask {
 
     private final Path pluginOutputDir = Paths.get(getProject().getRootProject().getBuildDir().getPath(), "gradle-dep-tree");
     private final boolean includeAllBuildFiles;
+    private final boolean includeIncludedBuilds;
 
     public GenerateDepTrees() {
         includeAllBuildFiles = Boolean.parseBoolean(System.getProperty(INCLUDE_ALL_BUILD_FILES, "false"));
+        includeIncludedBuilds = Boolean.parseBoolean(System.getProperty(INCLUDE_INCLUDED_BUILDS, "false"));
         // When scanning all build files from the root task, subproject task instances are redundant
         // and would race on the summary file if they also wrote it.
         setImpliesSubProjects(!includeAllBuildFiles);
@@ -212,7 +214,7 @@ public class GenerateDepTrees extends DefaultTask {
             }
         }
 
-        if (Boolean.parseBoolean(System.getProperty(INCLUDE_INCLUDED_BUILDS))) {
+        if (includeIncludedBuilds) {
             try {
                 for (IncludedBuildState b : getBuildStateRegistry().getIncludedBuilds()) {
                     for (ProjectState ps : b.getProjects().getAllProjects()) {

--- a/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
+++ b/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
@@ -42,14 +42,20 @@ public class GenerateDepTrees extends DefaultTask {
     private final Path pluginOutputDir = Paths.get(getProject().getRootProject().getBuildDir().getPath(), "gradle-dep-tree");
 
     public GenerateDepTrees() {
-        // Disables executing this task on subprojects
-        setImpliesSubProjects(true);
+        boolean includeAllBuildFiles = Boolean.parseBoolean(System.getProperty(INCLUDE_ALL_BUILD_FILES, "false"));
+        // When scanning all build files from the root task, subproject task instances are redundant
+        // and cause summary-file races via competing finalizers.
+        setImpliesSubProjects(!includeAllBuildFiles);
         setOnlyIf(element -> {
             if (System.getProperty(OUTPUT_FILE_PROPERTY) == null) {
                 throw new GradleException("'" + OUTPUT_FILE_PROPERTY + "' system property is mandatory");
             }
             return true;
         });
+
+        if (getProject() == getProject().getRootProject() || !includeAllBuildFiles) {
+            doLast("writeDepTreeSummary", task -> writeDepTreeSummary());
+        }
 
         // On Gradle 7.4+, mark this task as incompatible with the configuration cache
         List<Integer> gradleVersionParts = Arrays.stream(getProject().getGradle().getGradleVersion().split("\\."))
@@ -113,25 +119,42 @@ public class GenerateDepTrees extends DefaultTask {
         }
     }
 
-    /**
-     * Write the summary to the stdout after the task finished.
-     *
-     * @return task dependency.
-     */
-    @Internal
-    @Override
-    @Nonnull
-    public TaskDependency getFinalizedBy() {
+    private void writeDepTreeSummary() {
         String outputFile = System.getProperty(OUTPUT_FILE_PROPERTY);
+        if (outputFile == null) {
+            return;
+        }
+        List<File> writtenFiles = listExistingOutputFiles();
+        if (writtenFiles.isEmpty()) {
+            throw new GradleException("generateDepTrees produced no output files under " + pluginOutputDir);
+        }
         try (FileWriter writer = new FileWriter(outputFile, false)) {
-            for (File file : getOutputFiles()) {
+            for (File file : writtenFiles) {
                 writer.append(file.getAbsolutePath()).append(System.lineSeparator());
             }
             writer.flush();
         } catch (IOException e) {
             throw new GradleException("File '" + outputFile + "' is not writable", e);
         }
-        return super.getFinalizedBy();
+    }
+
+    private List<File> listExistingOutputFiles() {
+        List<File> writtenFiles = new ArrayList<>();
+        File outputDir = pluginOutputDir.toFile();
+        if (!outputDir.isDirectory()) {
+            return writtenFiles;
+        }
+        File[] files = outputDir.listFiles();
+        if (files == null) {
+            return writtenFiles;
+        }
+        Arrays.sort(files, Comparator.comparing(File::getName));
+        for (File file : files) {
+            if (file.isFile()) {
+                writtenFiles.add(file);
+            }
+        }
+        return writtenFiles;
     }
 
     /**

--- a/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
+++ b/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
@@ -40,11 +40,12 @@ public class GenerateDepTrees extends DefaultTask {
     public static final String INCLUDE_INCLUDED_BUILDS = "com.jfrog.includeIncludedBuilds";
 
     private final Path pluginOutputDir = Paths.get(getProject().getRootProject().getBuildDir().getPath(), "gradle-dep-tree");
+    private final boolean includeAllBuildFiles;
 
     public GenerateDepTrees() {
-        boolean includeAllBuildFiles = Boolean.parseBoolean(System.getProperty(INCLUDE_ALL_BUILD_FILES, "false"));
+        includeAllBuildFiles = Boolean.parseBoolean(System.getProperty(INCLUDE_ALL_BUILD_FILES, "false"));
         // When scanning all build files from the root task, subproject task instances are redundant
-        // and cause summary-file races via competing finalizers.
+        // and would race on the summary file if they also wrote it.
         setImpliesSubProjects(!includeAllBuildFiles);
         setOnlyIf(element -> {
             if (System.getProperty(OUTPUT_FILE_PROPERTY) == null) {
@@ -113,11 +114,6 @@ public class GenerateDepTrees extends DefaultTask {
             // Write output to file
             Utils.saveToFileAsJson(getProjectOutputFile(project), results);
         }
-        writeDepTreeSummaryIfResponsible();
-    }
-
-    private void writeDepTreeSummaryIfResponsible() {
-        boolean includeAllBuildFiles = Boolean.parseBoolean(System.getProperty(INCLUDE_ALL_BUILD_FILES, "false"));
         if (getProject() == getProject().getRootProject() || !includeAllBuildFiles) {
             writeDepTreeSummary();
         }
@@ -209,7 +205,6 @@ public class GenerateDepTrees extends DefaultTask {
         Project rootProj = getProject();
 
         projectsMap.put(rootProj.getPath(), rootProj);
-        boolean includeAllBuildFiles = Boolean.parseBoolean(System.getProperty(INCLUDE_ALL_BUILD_FILES));
 
         for (Project project : rootProj.getSubprojects()) {
             if (includeAllBuildFiles || !project.getBuildFile().exists()) {

--- a/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
+++ b/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
@@ -53,15 +53,6 @@ public class GenerateDepTrees extends DefaultTask {
             return true;
         });
 
-        if (getProject() == getProject().getRootProject() || !includeAllBuildFiles) {
-            // doLast runs even when a @CacheableTask is UP_TO_DATE on Gradle < 7.6; skip summary in that case.
-            doLast("writeDepTreeSummary", task -> {
-                if (task.getState().getDidWork()) {
-                    writeDepTreeSummary();
-                }
-            });
-        }
-
         // On Gradle 7.4+, mark this task as incompatible with the configuration cache
         List<Integer> gradleVersionParts = Arrays.stream(getProject().getGradle().getGradleVersion().split("\\."))
                 .map(Integer::valueOf)
@@ -121,6 +112,14 @@ public class GenerateDepTrees extends DefaultTask {
             GradleDepTreeResults results = createProjectDependencyTree(project);
             // Write output to file
             Utils.saveToFileAsJson(getProjectOutputFile(project), results);
+        }
+        writeDepTreeSummaryIfResponsible();
+    }
+
+    private void writeDepTreeSummaryIfResponsible() {
+        boolean includeAllBuildFiles = Boolean.parseBoolean(System.getProperty(INCLUDE_ALL_BUILD_FILES, "false"));
+        if (getProject() == getProject().getRootProject() || !includeAllBuildFiles) {
+            writeDepTreeSummary();
         }
     }
 

--- a/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
+++ b/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
@@ -54,7 +54,12 @@ public class GenerateDepTrees extends DefaultTask {
         });
 
         if (getProject() == getProject().getRootProject() || !includeAllBuildFiles) {
-            doLast("writeDepTreeSummary", task -> writeDepTreeSummary());
+            // doLast runs even when a @CacheableTask is UP_TO_DATE on Gradle < 7.6; skip summary in that case.
+            doLast("writeDepTreeSummary", task -> {
+                if (task.getState().getDidWork()) {
+                    writeDepTreeSummary();
+                }
+            });
         }
 
         // On Gradle 7.4+, mark this task as incompatible with the configuration cache


### PR DESCRIPTION
## `fix(generateDepTrees): write complete summary for root container projects`

## Summary

Fixes a bug where `generateDepTrees` could produce a summary file that references missing output files in root-container multi-project layouts (where `rootProject.name` differs from the subproject that carries dependencies, e.g. `custom-applications` + `CALINDI`).

The summary is now written at the end of `@TaskAction` by scanning the actual output directory, and subproject task instances are skipped when `includeAllBuildFiles=true` to avoid summary-file races. This also preserves `@CacheableTask` `UP_TO_DATE` behavior on Gradle versions before 7.6.

## Changes

- **`GenerateDepTrees`**: Replace `getFinalizedBy()` side-effect summary writing with `writeDepTreeSummary()` called from `@TaskAction`
- **`GenerateDepTrees`**: Build the summary from files on disk under `build/gradle-dep-tree/` instead of the task's declared `@OutputFiles`
- **`GenerateDepTrees`**: Set `impliesSubProjects` to `false` when `includeAllBuildFiles=true`, so only the root task writes the summary
- **`GenerateDepTrees`**: Canonicalize and validate the user-provided summary output path
- **Tests**: Add `root-container` functional fixture and `RootContainerProjectTest` regression test
- **Tests**: Add Frogbot ignore annotations in functional test utilities
