### PR TITLE
Exclude test dependencies option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,23 @@ Inject the plugin using the [init.gradle](./init.gradle) initialization script, 
 directory containing a build.gradle file. The plugin will generate a dependency tree for each subproject that does not
 contain a build.gradle file. To generate a dependency tree for each subproject that contains a Gradle build file, set the `-Dcom.jfrog.includeAllBuildFiles` flag to `true`.
 
-To skip Gradle test configurations (`testImplementation`, `testCompileClasspath`, `androidTest*`, etc.), set
-`-Dcom.jfrog.excludeTestConfigurations=true`. Debug/release configurations that do not contain `test` in the name are
-still included.
+To skip Gradle configurations whose names match a regex, set
+`-Dcom.jfrog.excludeConfigurationsPattern=<regex>`. For example, to skip names containing
+`test` case-insensitively (including `testImplementation`, `androidTest*`, and also
+`testFixtures*` / accidental substring hits like `latestReleaseApi`):
+
+```bash
+gradle clean generateDepTrees -I <path/to/init.gradle> -q \
+  -Dcom.jfrog.depsTreeOutputFile=<path/to/output/file> \
+  -Dcom.jfrog.excludeConfigurationsPattern=(?i)test
+```
+
+If the property is omitted or blank, all configurations are included. Invalid regex fails the task.
 
 The command:
 
 ```bash
 gradle clean generateDepTrees -I <path/to/init.gradle> -q -Dcom.jfrog.depsTreeOutputFile=<path/to/output/file>
-```
-
-Exclude test configurations:
-
-```bash
-gradle clean generateDepTrees -I <path/to/init.gradle> -q \
-  -Dcom.jfrog.depsTreeOutputFile=<path/to/output/file> \
-  -Dcom.jfrog.excludeTestConfigurations=true
 ```
 
 Output:

--- a/README.md
+++ b/README.md
@@ -14,10 +14,22 @@ Inject the plugin using the [init.gradle](./init.gradle) initialization script, 
 directory containing a build.gradle file. The plugin will generate a dependency tree for each subproject that does not
 contain a build.gradle file. To generate a dependency tree for each subproject that contains a Gradle build file, set the `-Dcom.jfrog.includeAllBuildFiles` flag to `true`.
 
+To skip Gradle test configurations (`testImplementation`, `testCompileClasspath`, `androidTest*`, etc.), set
+`-Dcom.jfrog.excludeTestConfigurations=true`. Debug/release configurations that do not contain `test` in the name are
+still included.
+
 The command:
 
 ```bash
 gradle clean generateDepTrees -I <path/to/init.gradle> -q -Dcom.jfrog.depsTreeOutputFile=<path/to/output/file>
+```
+
+Exclude test configurations:
+
+```bash
+gradle clean generateDepTrees -I <path/to/init.gradle> -q \
+  -Dcom.jfrog.depsTreeOutputFile=<path/to/output/file> \
+  -Dcom.jfrog.excludeTestConfigurations=true
 ```
 
 Output:

--- a/src/functionalTest/java/com/jfrog/tasks/BasicProjectTest.java
+++ b/src/functionalTest/java/com/jfrog/tasks/BasicProjectTest.java
@@ -16,6 +16,7 @@ import static com.jfrog.tasks.Consts.BASIC;
 import static com.jfrog.tasks.Consts.TEST_DIR;
 import static com.jfrog.tasks.Utils.*;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 /**
  * Functional tests for the project under resources/basic/
@@ -42,6 +43,23 @@ public class BasicProjectTest extends FunctionalTestBase {
                 assertDirectChild(results, "junit:junit:4.12", "testImplementation", false);
                 assertDirectChild(results, "joda-time:joda-time:2.2", "implementation", false);
                 assertDirectChild(results, "missing:dependency:404", "testImplementation", true);
+            }
+        }
+    }
+
+    @Test(dataProvider = "gradleVersions")
+    public void testBasicProjectExcludeTestConfigurations(String gradleVersion) throws IOException {
+        generateDepTrees(gradleVersion, false, true, Paths.get("."));
+        Path outputDir = TEST_DIR.toPath().resolve("build").resolve("gradle-dep-tree");
+        try (Stream<Path> files = Files.list(outputDir)) {
+            Set<String> actualProjects = files.map(Path::getFileName).map(Path::toString).collect(Collectors.toSet());
+            assertEquals(1, actualProjects.size());
+            for (String actualProject : actualProjects) {
+                GradleDepTreeResults results = objectMapper.readValue(outputDir.resolve(actualProject).toFile(), GradleDepTreeResults.class);
+                assertDirectChild(results, "joda-time:joda-time:2.2", "implementation", false);
+                assertFalse(results.getNodes().containsKey("junit:junit:4.12"));
+                assertFalse(results.getNodes().containsKey("missing:dependency:404"));
+                assertFalse(results.getNodes().get(results.getRoot()).getChildren().contains("junit:junit:4.12"));
             }
         }
     }

--- a/src/functionalTest/java/com/jfrog/tasks/BasicProjectTest.java
+++ b/src/functionalTest/java/com/jfrog/tasks/BasicProjectTest.java
@@ -48,8 +48,8 @@ public class BasicProjectTest extends FunctionalTestBase {
     }
 
     @Test(dataProvider = "gradleVersions")
-    public void testBasicProjectExcludeTestConfigurations(String gradleVersion) throws IOException {
-        generateDepTrees(gradleVersion, false, true, Paths.get("."));
+    public void testBasicProjectExcludeConfigurationsPattern(String gradleVersion) throws IOException {
+        generateDepTrees(gradleVersion, false, "(?i)test", Paths.get("."));
         Path outputDir = TEST_DIR.toPath().resolve("build").resolve("gradle-dep-tree");
         try (Stream<Path> files = Files.list(outputDir)) {
             Set<String> actualProjects = files.map(Path::getFileName).map(Path::toString).collect(Collectors.toSet());

--- a/src/functionalTest/java/com/jfrog/tasks/Utils.java
+++ b/src/functionalTest/java/com/jfrog/tasks/Utils.java
@@ -14,13 +14,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.jfrog.tasks.Consts.TEST_DIR;
-import static com.jfrog.tasks.GenerateDepTrees.EXCLUDE_TEST_CONFIGURATIONS;
+import static com.jfrog.tasks.GenerateDepTrees.EXCLUDE_CONFIGURATIONS_PATTERN;
 import static com.jfrog.tasks.GenerateDepTrees.INCLUDE_ALL_BUILD_FILES;
 import static com.jfrog.tasks.GenerateDepTrees.OUTPUT_FILE_PROPERTY;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
@@ -57,43 +58,44 @@ public class Utils {
     /**
      * Run and assert generateDepTrees task.
      *
-     * @param gradleVersion - The Gradle version to use
-     * @param projectNames  - The project names to use
+     * @param gradleVersion        - The Gradle version to use
+     * @param includeAllBuildFiles - Whether to include all build files
+     * @param projectNames         - The project names to use
      * @throws IOException in case of any I/O error.
      */
     static void generateDepTrees(String gradleVersion, boolean includeAllBuildFiles, Path... projectNames) throws IOException {
-        generateDepTrees(gradleVersion, includeAllBuildFiles, false, projectNames);
+        generateDepTrees(gradleVersion, includeAllBuildFiles, null, projectNames);
     }
 
     /**
      * Run and assert generateDepTrees task.
      *
-     * @param gradleVersion              - The Gradle version to use
-     * @param includeAllBuildFiles       - Whether to include all build files
-     * @param excludeTestConfigurations  - Whether to skip Gradle test configurations
-     * @param projectNames               - The project names to use
+     * @param gradleVersion                 - The Gradle version to use
+     * @param includeAllBuildFiles          - Whether to include all build files
+     * @param excludeConfigurationsPattern  - Regex of configuration names to exclude; null/blank means none
+     * @param projectNames                  - The project names to use
      * @throws IOException in case of any I/O error.
      */
-    static void generateDepTrees(String gradleVersion, boolean includeAllBuildFiles, boolean excludeTestConfigurations, Path... projectNames) throws IOException {
+    static void generateDepTrees(String gradleVersion, boolean includeAllBuildFiles, String excludeConfigurationsPattern, Path... projectNames) throws IOException {
         Path outputFile = Files.createTempFile("gradle-deps-tree-test", "");
         try {
             for (Path projectName : projectNames) {
                 File projectDir = TEST_DIR.toPath().resolve(projectName).toFile();
 
                 // Run generateDepTrees and assert success
-                BuildResult result = runGenerateDepTrees(gradleVersion, projectDir, outputFile, includeAllBuildFiles, excludeTestConfigurations);
+                BuildResult result = runGenerateDepTrees(gradleVersion, projectDir, outputFile, includeAllBuildFiles, excludeConfigurationsPattern);
                 assertSuccess(result);
                 assertOutput(outputFile);
 
                 // Run generateDepTrees and make sure the task was cached
-                result = runGenerateDepTrees(gradleVersion, projectDir, outputFile, includeAllBuildFiles, excludeTestConfigurations);
+                result = runGenerateDepTrees(gradleVersion, projectDir, outputFile, includeAllBuildFiles, excludeConfigurationsPattern);
                 assertUpToDate(result);
                 assertOutput(outputFile);
 
                 // Make a change in build.gradle file and make sure the cache was invalidated after running generateDepTrees
                 // jfrog-ignore: this is a test
                 Files.write(projectDir.toPath().resolve("build.gradle"), "\n".getBytes(), StandardOpenOption.APPEND);
-                result = runGenerateDepTrees(gradleVersion, projectDir, outputFile, includeAllBuildFiles, excludeTestConfigurations);
+                result = runGenerateDepTrees(gradleVersion, projectDir, outputFile, includeAllBuildFiles, excludeConfigurationsPattern);
                 assertSuccess(result);
                 assertOutput(outputFile);
             }
@@ -176,21 +178,29 @@ public class Utils {
     /**
      * Run Gradle process with the GradleRunner.
      *
-     * @param gradleVersion - The Gradle version to use
-     * @param projectDir    - The project directory
-     * @param outputFile    - The output file
+     * @param gradleVersion                - The Gradle version to use
+     * @param projectDir                   - The project directory
+     * @param outputFile                   - The output file
+     * @param includeAllBuildFiles         - Whether to include all build files
+     * @param excludeConfigurationsPattern - Regex of configuration names to exclude; null/blank omits the flag
      * @return the build results.
      */
-    private static BuildResult runGenerateDepTrees(String gradleVersion, File projectDir, Path outputFile, boolean includeAllBuildFiles, boolean excludeTestConfigurations) {
+    private static BuildResult runGenerateDepTrees(String gradleVersion, File projectDir, Path outputFile,
+                                                   boolean includeAllBuildFiles, String excludeConfigurationsPattern) {
+        List<String> args = new ArrayList<>();
+        args.add("generateDepTrees");
+        args.add("-q");
+        args.add("-D" + INCLUDE_ALL_BUILD_FILES + "=" + includeAllBuildFiles);
+        if (excludeConfigurationsPattern != null && !excludeConfigurationsPattern.trim().isEmpty()) {
+            args.add("-D" + EXCLUDE_CONFIGURATIONS_PATTERN + "=" + excludeConfigurationsPattern);
+        }
+        args.add("-D" + OUTPUT_FILE_PROPERTY + "=" + outputFile.toAbsolutePath());
         return GradleRunner.create()
                 .withGradleVersion(gradleVersion)
                 .withProjectDir(projectDir)
                 .withPluginClasspath()
                 .withDebug(true)
-                .withArguments("generateDepTrees", "-q",
-                        "-D" + INCLUDE_ALL_BUILD_FILES + "=" + includeAllBuildFiles,
-                        "-D" + EXCLUDE_TEST_CONFIGURATIONS + "=" + excludeTestConfigurations,
-                        "-D" + OUTPUT_FILE_PROPERTY + "=" + outputFile.toAbsolutePath())
+                .withArguments(args)
                 .build();
     }
 }

--- a/src/functionalTest/java/com/jfrog/tasks/Utils.java
+++ b/src/functionalTest/java/com/jfrog/tasks/Utils.java
@@ -182,18 +182,22 @@ public class Utils {
      * @param projectDir                   - The project directory
      * @param outputFile                   - The output file
      * @param includeAllBuildFiles         - Whether to include all build files
-     * @param excludeConfigurationsPattern - Regex of configuration names to exclude; null/blank omits the flag
+     * @param excludeConfigurationsPattern - Regex of configuration names to exclude; null/blank means none
      * @return the build results.
      */
     private static BuildResult runGenerateDepTrees(String gradleVersion, File projectDir, Path outputFile,
                                                    boolean includeAllBuildFiles, String excludeConfigurationsPattern) {
+        // Always pass the pattern property. TestKit withDebug(true) shares the test JVM, so omitting
+        // -D after a prior run that set (?i)test would leak into later tests via System.getProperty.
+        String pattern = excludeConfigurationsPattern == null ? "" : excludeConfigurationsPattern.trim();
+        if (pattern.isEmpty()) {
+            System.clearProperty(EXCLUDE_CONFIGURATIONS_PATTERN);
+        }
         List<String> args = new ArrayList<>();
         args.add("generateDepTrees");
         args.add("-q");
         args.add("-D" + INCLUDE_ALL_BUILD_FILES + "=" + includeAllBuildFiles);
-        if (excludeConfigurationsPattern != null && !excludeConfigurationsPattern.trim().isEmpty()) {
-            args.add("-D" + EXCLUDE_CONFIGURATIONS_PATTERN + "=" + excludeConfigurationsPattern);
-        }
+        args.add("-D" + EXCLUDE_CONFIGURATIONS_PATTERN + "=" + pattern);
         args.add("-D" + OUTPUT_FILE_PROPERTY + "=" + outputFile.toAbsolutePath());
         return GradleRunner.create()
                 .withGradleVersion(gradleVersion)

--- a/src/functionalTest/java/com/jfrog/tasks/Utils.java
+++ b/src/functionalTest/java/com/jfrog/tasks/Utils.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.jfrog.tasks.Consts.TEST_DIR;
+import static com.jfrog.tasks.GenerateDepTrees.EXCLUDE_TEST_CONFIGURATIONS;
 import static com.jfrog.tasks.GenerateDepTrees.INCLUDE_ALL_BUILD_FILES;
 import static com.jfrog.tasks.GenerateDepTrees.OUTPUT_FILE_PROPERTY;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
@@ -61,25 +62,38 @@ public class Utils {
      * @throws IOException in case of any I/O error.
      */
     static void generateDepTrees(String gradleVersion, boolean includeAllBuildFiles, Path... projectNames) throws IOException {
+        generateDepTrees(gradleVersion, includeAllBuildFiles, false, projectNames);
+    }
+
+    /**
+     * Run and assert generateDepTrees task.
+     *
+     * @param gradleVersion              - The Gradle version to use
+     * @param includeAllBuildFiles       - Whether to include all build files
+     * @param excludeTestConfigurations  - Whether to skip Gradle test configurations
+     * @param projectNames               - The project names to use
+     * @throws IOException in case of any I/O error.
+     */
+    static void generateDepTrees(String gradleVersion, boolean includeAllBuildFiles, boolean excludeTestConfigurations, Path... projectNames) throws IOException {
         Path outputFile = Files.createTempFile("gradle-deps-tree-test", "");
         try {
             for (Path projectName : projectNames) {
                 File projectDir = TEST_DIR.toPath().resolve(projectName).toFile();
 
                 // Run generateDepTrees and assert success
-                BuildResult result = runGenerateDepTrees(gradleVersion, projectDir, outputFile, includeAllBuildFiles);
+                BuildResult result = runGenerateDepTrees(gradleVersion, projectDir, outputFile, includeAllBuildFiles, excludeTestConfigurations);
                 assertSuccess(result);
                 assertOutput(outputFile);
 
                 // Run generateDepTrees and make sure the task was cached
-                result = runGenerateDepTrees(gradleVersion, projectDir, outputFile, includeAllBuildFiles);
+                result = runGenerateDepTrees(gradleVersion, projectDir, outputFile, includeAllBuildFiles, excludeTestConfigurations);
                 assertUpToDate(result);
                 assertOutput(outputFile);
 
                 // Make a change in build.gradle file and make sure the cache was invalidated after running generateDepTrees
                 // jfrog-ignore: this is a test
                 Files.write(projectDir.toPath().resolve("build.gradle"), "\n".getBytes(), StandardOpenOption.APPEND);
-                result = runGenerateDepTrees(gradleVersion, projectDir, outputFile, includeAllBuildFiles);
+                result = runGenerateDepTrees(gradleVersion, projectDir, outputFile, includeAllBuildFiles, excludeTestConfigurations);
                 assertSuccess(result);
                 assertOutput(outputFile);
             }
@@ -167,13 +181,16 @@ public class Utils {
      * @param outputFile    - The output file
      * @return the build results.
      */
-    private static BuildResult runGenerateDepTrees(String gradleVersion, File projectDir, Path outputFile, boolean includeAllBuildFiles) {
+    private static BuildResult runGenerateDepTrees(String gradleVersion, File projectDir, Path outputFile, boolean includeAllBuildFiles, boolean excludeTestConfigurations) {
         return GradleRunner.create()
                 .withGradleVersion(gradleVersion)
                 .withProjectDir(projectDir)
                 .withPluginClasspath()
                 .withDebug(true)
-                .withArguments("generateDepTrees", "-q", "-D" + INCLUDE_ALL_BUILD_FILES + "=" + includeAllBuildFiles, "-D" + OUTPUT_FILE_PROPERTY + "=" + outputFile.toAbsolutePath())
+                .withArguments("generateDepTrees", "-q",
+                        "-D" + INCLUDE_ALL_BUILD_FILES + "=" + includeAllBuildFiles,
+                        "-D" + EXCLUDE_TEST_CONFIGURATIONS + "=" + excludeTestConfigurations,
+                        "-D" + OUTPUT_FILE_PROPERTY + "=" + outputFile.toAbsolutePath())
                 .build();
     }
 }

--- a/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
+++ b/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
@@ -22,6 +22,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 import static com.jfrog.GradleDependencyTreeUtils.addConfiguration;
@@ -38,17 +40,18 @@ public class GenerateDepTrees extends DefaultTask {
     public static final String INCLUDE_ALL_BUILD_FILES = "com.jfrog.includeAllBuildFiles";
     public static final String CURATION_AUDIT_MODE = "com.jfrog.curationAuditMode";
     public static final String INCLUDE_INCLUDED_BUILDS = "com.jfrog.includeIncludedBuilds";
-    public static final String EXCLUDE_TEST_CONFIGURATIONS = "com.jfrog.excludeTestConfigurations";
+    public static final String EXCLUDE_CONFIGURATIONS_PATTERN = "com.jfrog.excludeConfigurationsPattern";
 
     private final Path pluginOutputDir = Paths.get(getProject().getRootProject().getBuildDir().getPath(), "gradle-dep-tree");
     private final boolean includeAllBuildFiles;
     private final boolean includeIncludedBuilds;
-    private final boolean excludeTestConfigurations;
+    private final String excludeConfigurationsPattern;
 
     public GenerateDepTrees() {
         includeAllBuildFiles = Boolean.parseBoolean(System.getProperty(INCLUDE_ALL_BUILD_FILES, "false"));
         includeIncludedBuilds = Boolean.parseBoolean(System.getProperty(INCLUDE_INCLUDED_BUILDS, "false"));
-        excludeTestConfigurations = Boolean.parseBoolean(System.getProperty(EXCLUDE_TEST_CONFIGURATIONS, "false"));
+        String patternProp = System.getProperty(EXCLUDE_CONFIGURATIONS_PATTERN);
+        excludeConfigurationsPattern = patternProp == null ? "" : patternProp.trim();
         // When scanning all build files from the root task, subproject task instances are redundant
         // and would race on the summary file if they also wrote it.
         setImpliesSubProjects(!includeAllBuildFiles);
@@ -112,13 +115,12 @@ public class GenerateDepTrees extends DefaultTask {
     }
 
     /**
-     * Whether test configurations (names containing {@code test}, e.g. testImplementation,
-     * androidTestCompileClasspath) are skipped when building the dependency tree.
-     * Controlled by {@link #EXCLUDE_TEST_CONFIGURATIONS}.
+     * Regex used to skip matching Gradle configuration names when building the dependency tree.
+     * Empty means no configurations are excluded. Controlled by {@link #EXCLUDE_CONFIGURATIONS_PATTERN}.
      */
     @Input
-    public boolean getExcludeTestConfigurations() {
-        return excludeTestConfigurations;
+    public String getExcludeConfigurationsPattern() {
+        return excludeConfigurationsPattern;
     }
 
     @TaskAction
@@ -283,8 +285,9 @@ public class GenerateDepTrees extends DefaultTask {
         // This avoids issues caused by dynamic modifications by other Gradle plugins.
         ConfigurationContainer configsContainer = project.getConfigurations();
         Set<String> names = new HashSet<>(configsContainer.getNames());
+        Pattern excludePattern = compileExcludePattern(excludeConfigurationsPattern);
         for (String name : names) {
-            if (excludeTestConfigurations && isTestConfiguration(name)) {
+            if (excludePattern != null && name != null && excludePattern.matcher(name).find()) {
                 continue;
             }
             // Pass `project` so synthesizeProjectNodeId can resolve sibling subprojects
@@ -295,12 +298,32 @@ public class GenerateDepTrees extends DefaultTask {
     }
 
     /**
-     * Returns true when the Gradle configuration name is a test scope
-     * ({@code testImplementation}, {@code testCompileClasspath}, {@code androidTest*}, etc.).
-     * Debug/release variant names without {@code test} are not treated as test configurations.
+     * Returns true when {@code configurationName} should be skipped for the given exclude regex.
+     * Blank/null {@code pattern} never excludes. Invalid patterns throw {@link IllegalArgumentException}.
      */
-    public static boolean isTestConfiguration(String configurationName) {
-        return configurationName != null && configurationName.toLowerCase(Locale.ROOT).contains("test");
+    public static boolean shouldExcludeConfiguration(String configurationName, String pattern) {
+        if (pattern == null || pattern.trim().isEmpty()) {
+            return false;
+        }
+        if (configurationName == null) {
+            return false;
+        }
+        try {
+            return Pattern.compile(pattern).matcher(configurationName).find();
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException("Invalid " + EXCLUDE_CONFIGURATIONS_PATTERN + ": " + pattern, e);
+        }
+    }
+
+    private static Pattern compileExcludePattern(String pattern) {
+        if (pattern == null || pattern.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return Pattern.compile(pattern);
+        } catch (PatternSyntaxException e) {
+            throw new GradleException("Invalid " + EXCLUDE_CONFIGURATIONS_PATTERN + ": " + pattern, e);
+        }
     }
 
     private String getProjectModuleId(Project project) {

--- a/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
+++ b/src/main/java/com/jfrog/tasks/GenerateDepTrees.java
@@ -38,14 +38,17 @@ public class GenerateDepTrees extends DefaultTask {
     public static final String INCLUDE_ALL_BUILD_FILES = "com.jfrog.includeAllBuildFiles";
     public static final String CURATION_AUDIT_MODE = "com.jfrog.curationAuditMode";
     public static final String INCLUDE_INCLUDED_BUILDS = "com.jfrog.includeIncludedBuilds";
+    public static final String EXCLUDE_TEST_CONFIGURATIONS = "com.jfrog.excludeTestConfigurations";
 
     private final Path pluginOutputDir = Paths.get(getProject().getRootProject().getBuildDir().getPath(), "gradle-dep-tree");
     private final boolean includeAllBuildFiles;
     private final boolean includeIncludedBuilds;
+    private final boolean excludeTestConfigurations;
 
     public GenerateDepTrees() {
         includeAllBuildFiles = Boolean.parseBoolean(System.getProperty(INCLUDE_ALL_BUILD_FILES, "false"));
         includeIncludedBuilds = Boolean.parseBoolean(System.getProperty(INCLUDE_INCLUDED_BUILDS, "false"));
+        excludeTestConfigurations = Boolean.parseBoolean(System.getProperty(EXCLUDE_TEST_CONFIGURATIONS, "false"));
         // When scanning all build files from the root task, subproject task instances are redundant
         // and would race on the summary file if they also wrote it.
         setImpliesSubProjects(!includeAllBuildFiles);
@@ -106,6 +109,16 @@ public class GenerateDepTrees extends DefaultTask {
             outputFiles.add(getProjectOutputFile(project));
         }
         return outputFiles;
+    }
+
+    /**
+     * Whether test configurations (names containing {@code test}, e.g. testImplementation,
+     * androidTestCompileClasspath) are skipped when building the dependency tree.
+     * Controlled by {@link #EXCLUDE_TEST_CONFIGURATIONS}.
+     */
+    @Input
+    public boolean getExcludeTestConfigurations() {
+        return excludeTestConfigurations;
     }
 
     @TaskAction
@@ -271,11 +284,23 @@ public class GenerateDepTrees extends DefaultTask {
         ConfigurationContainer configsContainer = project.getConfigurations();
         Set<String> names = new HashSet<>(configsContainer.getNames());
         for (String name : names) {
+            if (excludeTestConfigurations && isTestConfiguration(name)) {
+                continue;
+            }
             // Pass `project` so synthesizeProjectNodeId can resolve sibling subprojects
             // (keeps synthesized ids aligned with getProjectModuleId).
             addConfiguration(project, root, configsContainer.getByName(name), nodes);
         }
         return new GradleDepTreeResults(rootId, nodes);
+    }
+
+    /**
+     * Returns true when the Gradle configuration name is a test scope
+     * ({@code testImplementation}, {@code testCompileClasspath}, {@code androidTest*}, etc.).
+     * Debug/release variant names without {@code test} are not treated as test configurations.
+     */
+    public static boolean isTestConfiguration(String configurationName) {
+        return configurationName != null && configurationName.toLowerCase(Locale.ROOT).contains("test");
     }
 
     private String getProjectModuleId(Project project) {

--- a/src/test/java/com/jfrog/tasks/GenerateDepTreesTest.java
+++ b/src/test/java/com/jfrog/tasks/GenerateDepTreesTest.java
@@ -3,32 +3,44 @@ package com.jfrog.tasks;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static com.jfrog.tasks.GenerateDepTrees.isTestConfiguration;
+import static com.jfrog.tasks.GenerateDepTrees.shouldExcludeConfiguration;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
 
 public class GenerateDepTreesTest {
 
     @DataProvider
     public Object[][] configurationNames() {
         return new Object[][]{
-                {"testImplementation", true},
-                {"testCompileClasspath", true},
-                {"testRuntimeClasspath", true},
-                {"androidTestImplementation", true},
-                {"debugAndroidTestCompileClasspath", true},
-                {"compileClasspath", false},
-                {"runtimeClasspath", false},
-                {"implementation", false},
-                {"debugImplementation", false},
-                {"debugCompileClasspath", false},
-                {"releaseCompileClasspath", false},
-                {"A1ReleaseCompileClasspath", false},
-                {null, false},
+                // pattern (?i)test — case-insensitive substring
+                {"(?i)test", "testImplementation", true},
+                {"(?i)test", "testCompileClasspath", true},
+                {"(?i)test", "androidTestImplementation", true},
+                {"(?i)test", "debugAndroidTestCompileClasspath", true},
+                {"(?i)test", "testFixturesApi", true},
+                {"(?i)test", "latestReleaseApi", true},
+                {"(?i)test", "compileClasspath", false},
+                {"(?i)test", "implementation", false},
+                {"(?i)test", "debugCompileClasspath", false},
+                {"(?i)test", null, false},
+                // blank / null pattern = never exclude
+                {"", "testImplementation", false},
+                {null, "testImplementation", false},
+                {"   ", "testImplementation", false},
+                // custom pattern
+                {"^runtime", "runtimeClasspath", true},
+                {"^runtime", "compileClasspath", false},
         };
     }
 
     @Test(dataProvider = "configurationNames")
-    public void testIsTestConfiguration(String configurationName, boolean expected) {
-        assertEquals(isTestConfiguration(configurationName), expected);
+    public void testShouldExcludeConfiguration(String pattern, String configurationName, boolean expected) {
+        assertEquals(shouldExcludeConfiguration(configurationName, pattern), expected);
+    }
+
+    @Test
+    public void testInvalidPatternThrows() {
+        expectThrows(IllegalArgumentException.class,
+                () -> shouldExcludeConfiguration("implementation", "[invalid"));
     }
 }

--- a/src/test/java/com/jfrog/tasks/GenerateDepTreesTest.java
+++ b/src/test/java/com/jfrog/tasks/GenerateDepTreesTest.java
@@ -1,0 +1,34 @@
+package com.jfrog.tasks;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static com.jfrog.tasks.GenerateDepTrees.isTestConfiguration;
+import static org.testng.Assert.assertEquals;
+
+public class GenerateDepTreesTest {
+
+    @DataProvider
+    public Object[][] configurationNames() {
+        return new Object[][]{
+                {"testImplementation", true},
+                {"testCompileClasspath", true},
+                {"testRuntimeClasspath", true},
+                {"androidTestImplementation", true},
+                {"debugAndroidTestCompileClasspath", true},
+                {"compileClasspath", false},
+                {"runtimeClasspath", false},
+                {"implementation", false},
+                {"debugImplementation", false},
+                {"debugCompileClasspath", false},
+                {"releaseCompileClasspath", false},
+                {"A1ReleaseCompileClasspath", false},
+                {null, false},
+        };
+    }
+
+    @Test(dataProvider = "configurationNames")
+    public void testIsTestConfiguration(String configurationName, boolean expected) {
+        assertEquals(isTestConfiguration(configurationName), expected);
+    }
+}


### PR DESCRIPTION
- [ ] All [tests](../CONTRIBUTING.md#tests) passed. If this feature is not already covered by the tests, I added new
  tests.

-----

Add option to exclude `*test*` dependencies configurations when generating dep tree.
New input `com.jfrog.excludeTestConfigurations=true` to apply
